### PR TITLE
Use unaligned store and correct buffer sizes for numpy methods

### DIFF
--- a/src/impl/vamp/bindings/common.hh
+++ b/src/impl/vamp/bindings/common.hh
@@ -298,8 +298,8 @@ namespace vamp::binding
                 "numpy",
                 [](const typename RH::Configuration &v) noexcept
                 {
-                    auto *v_arr = new FloatT[Robot::dimension];
                     v.to_array(v_arr);
+                    auto *v_arr = new FloatT[RH::Configuration::num_scalars_rounded];
                     nb::capsule arr_owner(
                         v_arr, [](void *a) noexcept { delete[] reinterpret_cast<FloatT *>(a); });
                     return nb::ndarray<nb::numpy, const FloatT, nb::shape<Robot::dimension>, nb::device::cpu>(
@@ -358,8 +358,10 @@ namespace vamp::binding
                 "numpy",
                 [](const typename RH::Path &p) noexcept
                 {
-                    auto *path_arr = new FloatT[Robot::dimension * p.size()];
                     for (auto i = 0U; i < p.size(); i += Robot::dimension)
+                    auto *path_arr = new FloatT
+                        [Robot::dimension * p.size() +
+                         (RH::Configuration::num_scalars_rounded - Robot::dimension)];
                     {
                         p[i].to_array(path_arr + i);
                     }

--- a/src/impl/vamp/bindings/common.hh
+++ b/src/impl/vamp/bindings/common.hh
@@ -298,8 +298,8 @@ namespace vamp::binding
                 "numpy",
                 [](const typename RH::Configuration &v) noexcept
                 {
-                    v.to_array(v_arr);
                     auto *v_arr = new FloatT[RH::Configuration::num_scalars_rounded];
+                    v.to_array_unaligned(v_arr);
                     nb::capsule arr_owner(
                         v_arr, [](void *a) noexcept { delete[] reinterpret_cast<FloatT *>(a); });
                     return nb::ndarray<nb::numpy, const FloatT, nb::shape<Robot::dimension>, nb::device::cpu>(
@@ -358,12 +358,12 @@ namespace vamp::binding
                 "numpy",
                 [](const typename RH::Path &p) noexcept
                 {
-                    for (auto i = 0U; i < p.size(); i += Robot::dimension)
                     auto *path_arr = new FloatT
                         [Robot::dimension * p.size() +
                          (RH::Configuration::num_scalars_rounded - Robot::dimension)];
+                    for (auto i = 0U; i < p.size(); ++i)
                     {
-                        p[i].to_array(path_arr + i);
+                        p[i].to_array_unaligned(path_arr + i * Robot::dimension);
                     }
 
                     nb::capsule arr_owner(

--- a/src/impl/vamp/bindings/common.hh
+++ b/src/impl/vamp/bindings/common.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <vector>
 #include <vamp/collision/sphere_sphere.hh>
 #include <vamp/collision/validity.hh>
 #include <vamp/planning/validate.hh>

--- a/src/impl/vamp/planning/prm.hh
+++ b/src/impl/vamp/planning/prm.hh
@@ -213,9 +213,10 @@ namespace vamp::planning
             std::size_t iter = 0;
             std::vector<std::pair<NNNode<dimension>, float>> neighbors;
             typename Robot::template ConfigurationBlock<rake> temp_block;
-            auto states = std::unique_ptr<float>(
+            auto states = std::unique_ptr<float, decltype(&free)>(
                 vamp::utils::vector_alloc<float, FloatVectorAlignment, FloatVectorWidth>(
-                    settings.max_samples * Configuration::num_scalars_rounded));
+                    settings.max_samples * Configuration::num_scalars_rounded),
+                &free);
             // TODO: Is it better to just use arrays for these since we're reserving full capacity
             // anyway? Test it!
             std::vector<RoadmapNode> nodes;

--- a/src/impl/vamp/planning/rrtc.hh
+++ b/src/impl/vamp/planning/rrtc.hh
@@ -42,9 +42,10 @@ namespace vamp::planning
             constexpr const std::size_t start_index = 0;
             constexpr const std::size_t goal_index = 1;
 
-            auto buffer = std::unique_ptr<float>(
+            auto buffer = std::unique_ptr<float, decltype(&free)>(
                 vamp::utils::vector_alloc<float, FloatVectorAlignment, FloatVectorWidth>(
-                    settings.max_samples * Configuration::num_scalars_rounded));
+                    settings.max_samples * Configuration::num_scalars_rounded),
+                &free);
 
             const auto buffer_index = [&buffer](std::size_t index) -> float *
             { return buffer.get() + index * Configuration::num_scalars_rounded; };

--- a/src/impl/vamp/utils.hh
+++ b/src/impl/vamp/utils.hh
@@ -3,8 +3,6 @@
 #include <chrono>
 #include <utility>
 #include <cstdint>
-#include <vector>
-#include <algorithm>
 
 namespace vamp::utils
 {

--- a/src/impl/vamp/vector/avx.hh
+++ b/src/impl/vamp/vector/avx.hh
@@ -38,6 +38,12 @@ namespace vamp
         }
 
         template <unsigned int = 0>
+        inline static constexpr auto store_unaligned(ScalarT *f, VectorT v) noexcept -> void
+        {
+            _mm256_storeu_ps(f, v);
+        }
+
+        template <unsigned int = 0>
         inline static auto extract(VectorT v, int idx) noexcept -> ScalarT
         {
             return v[idx];
@@ -410,6 +416,12 @@ namespace vamp
         inline static constexpr auto store(ScalarT *f, VectorT v) noexcept -> void
         {
             _mm256_store_si256(reinterpret_cast<VectorT *>(f), v);
+        }
+
+        template <unsigned int = 0>
+        inline static constexpr auto store_unaligned(ScalarT *f, VectorT v) noexcept -> void
+        {
+            _mm256_storeu_si256(reinterpret_cast<VectorT *>(f), v);
         }
 
         template <unsigned int = 0>

--- a/src/impl/vamp/vector/interface.hh
+++ b/src/impl/vamp/vector/interface.hh
@@ -78,6 +78,11 @@ namespace vamp
             store_vector(buf, std::make_index_sequence<num_vectors>());
         }
 
+        inline constexpr void to_array_unaligned(typename S::ScalarT *buf) const noexcept
+        {
+            store_vector_unaligned(buf, std::make_index_sequence<num_vectors>());
+        }
+
         inline static constexpr auto fill(typename S::ScalarT f) noexcept -> D
         {
             return D(make_array(f, std::make_index_sequence<num_vectors>()));
@@ -742,6 +747,16 @@ namespace vamp
             // TODO: This might segfault if we had to over-allocate vectors and the scalar data isn't
             // full for the over-allocated size
             (..., (S::template store<0>(scalar_array + I * S::VectorWidth, std::get<I>(d()->data))));
+        }
+
+        template <std::size_t... I>
+        inline constexpr void
+        store_vector_unaligned(typename S::ScalarT *scalar_array, std::index_sequence<I...>) const noexcept
+        {
+            // TODO: This might segfault if we had to over-allocate vectors and the scalar data isn't
+            // full for the over-allocated size
+            (...,
+             (S::template store_unaligned<0>(scalar_array + I * S::VectorWidth, std::get<I>(d()->data))));
         }
 
         inline constexpr auto d() const noexcept -> const D *

--- a/src/impl/vamp/vector/neon.hh
+++ b/src/impl/vamp/vector/neon.hh
@@ -41,6 +41,12 @@ namespace vamp
         }
 
         template <unsigned int = 0>
+        inline static auto store_unaligned(ScalarT *f, VectorT v) noexcept -> void
+        {
+            return vst1q_f32(f, v);
+        }
+
+        template <unsigned int = 0>
         inline static auto extract(VectorT v, int idx) noexcept -> ScalarT
         {
             return v[idx];
@@ -486,6 +492,12 @@ namespace vamp
 
         template <unsigned int = 0>
         inline static auto store(ScalarT *i, VectorT v) noexcept -> void
+        {
+            return vst1q_s32(i, v);
+        }
+
+        template <unsigned int = 0>
+        inline static auto store_unaligned(ScalarT *i, VectorT v) noexcept -> void
         {
             return vst1q_s32(i, v);
         }


### PR DESCRIPTION
Fixes #9. 

In cases where a robot's dimension isn't a multiple of the vector width, it was possible to attempt to store a vector with an aligned store instruction (on x86 systems) to an unaligned address when outputting a path to a numpy array, resulting in a segfault. There were also some small errors in the indexing and buffer size, which could also have caused segfaults. We didn't see these errors before because (1) luck with robot state dimensions and (2) the problem does not seem to occur on ARM systems (e.g., Macbooks), which we used to try to reproduce #9.

This PR adds an unaligned store operation to the vector backend and a `to_array_unaligned` method using this operation to the vector interface to, in cases like this where performance isn't critical, simply use an unaligned store to avoid the segfault. It also fixes the indexing and buffer size issues and some miscellaneous memory-related warnings that cropped up with the new version of `g++`.

- **feat: Add store_unaligned and to_array_unaligned**
- **fix: Correct buffer alloc size for numpy methods**
- **fix: Correct bug in path numpy loop indexing and use to_array_unaligned**
- **misc: Cleanup (some) unused includes**
- **fix: Correctly specify deallocation function for unique_ptr with aligned memory**
