### PR TITLE
Fix typo bug with vreinterpretq + CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
         build_type: [Release]
         compiler: [{cpp: g++, c: gcc}, {cpp: clang++, c: clang}]
+        python: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -59,11 +60,8 @@ jobs:
     - name: Setup Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
+        python-version: ${{ matrix.python }}
         cache: 'pip'
-
-    - name: Install Python packages
-      run: >
-        pip install typing_extensions
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,26 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang]
-        include:
-          - os: ubuntu-20.04
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: ubuntu-20.04
-            c_compiler: clang
-            cpp_compiler: clang++
-          - os: ubuntu-22.04
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: ubuntu-22.04
-            c_compiler: clang
-            cpp_compiler: clang++
-          - os: macos-latest
-            c_compiler: clang
-            cpp_compiler: clang++
-          - os: macos-latest
-            c_compiler: gcc
-            cpp_compiler: g++
+        compiler: [{cpp: g++, c: gcc}, {cpp: clang++, c: clang}]
 
     steps:
     - uses: actions/checkout@v4
@@ -73,7 +54,7 @@ jobs:
         brew install eigen
 
     - name: Install GCC (MacOS)
-      if: runner.os == 'macOS' && matrix.c_compiler == 'gcc'
+      if: runner.os == 'macOS' && matrix.compiler.c == 'gcc'
       run: >
         brew install gcc
 
@@ -85,8 +66,8 @@ jobs:
     - name: Configure CMake
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }}
+        -DCMAKE_C_COMPILER=${{ matrix.compiler.c }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -S ${{ github.workspace }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,12 +41,10 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
-
     - name: Install packages (Linux)
       if: runner.os == 'Linux'
       run: >
         sudo apt-get install -y libeigen3-dev llvm
-
 
     - name: Install packages (MacOS)
       if: runner.os == 'macOS'
@@ -58,6 +56,10 @@ jobs:
       run: >
         brew install gcc
 
+    - name: Setup Python ${{ matrix.python }}
+      uses: actions/setup-python@v5
+      with:
+        cache: 'pip'
 
     - name: Install Python packages
       run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
-        cache: 'pip'
 
     - name: Configure CMake
       run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
         build_type: [Release]
         c_compiler: [gcc, clang]
         include:

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -3,7 +3,7 @@ find_package(Python 3.8
   REQUIRED COMPONENTS Interpreter Development.Module
   OPTIONAL_COMPONENTS Development.SABIModule)
 
-CPMAddPackage("gh:wjakob/nanobind#4ed5fdf80de460edc416c0e948d6e6c60e61a02a")
+CPMAddPackage("gh:wjakob/nanobind#b0136fe6ac1967cb2399456adc346a1af06a3b88")
 
 CPMAddPackage("gh:kavrakilab/nigh#97130999440647c204e0265d05a997dbd8da4e70")
 set(NIGH_INCLUDE_DIRS ${nigh_SOURCE_DIR}/src)

--- a/src/impl/vamp/vector/neon.hh
+++ b/src/impl/vamp/vector/neon.hh
@@ -216,7 +216,7 @@ namespace vamp
         template <unsigned int i>
         inline static constexpr auto lshift_dispatch(VectorT v) noexcept -> VectorT
         {
-            return vreinterpretq_u32_f32(vshlq_n_u32(vreinterpretq_u32_f32(v), i));
+            return vreinterpretq_f32_u32(vshlq_n_u32(vreinterpretq_u32_f32(v), i));
         }
 
         template <unsigned int = 0>
@@ -240,7 +240,7 @@ namespace vamp
         template <unsigned int i>
         inline static constexpr auto rshift_dispatch(VectorT v) noexcept -> VectorT
         {
-            return vreinterpretq_u32_f32(vshrq_n_u32(vreinterpretq_u32_f32(v), i));
+            return vreinterpretq_f32_u32(vshrq_n_u32(vreinterpretq_u32_f32(v), i));
         }
 
         template <unsigned int = 0>


### PR DESCRIPTION
Fixes #20. We had a typo in two uses of vreinterpretq which tried to cast the wrong direction. Not
sure why we didn't see this on other ARM platforms - maybe just more lenient compilers, since the
reinterpret should be a NOP.

Also updates/cleans up the build CI, since I was in there anyway checking if we had an ARM runner.
