### PR TITLE
fix: explicitly use float32 for numpy typing

### DIFF
--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union, List
 
-from numpy import float_
+from numpy import float32
 from numpy.typing import NDArray
 
 from .constants import *
@@ -123,7 +123,7 @@ def configure_robot_and_planner_with_kwargs(robot_name: str, planner_name: str, 
 
 
 def problem_dict_to_vamp(
-        problem: Dict[str, List[Dict[str, Union[float, NDArray[float_]]]]],
+        problem: Dict[str, List[Dict[str, Union[float, NDArray[float32]]]]],
         ignore_names: List[str] = []
     ) -> Environment:
     env = Environment()

--- a/src/vamp/pointcloud.py
+++ b/src/vamp/pointcloud.py
@@ -128,7 +128,7 @@ def problem_to_pointcloud(problem, n):
 
 def problem_dict_to_pointcloud(
         robot: str,
-        problem: Dict[str, List[Dict[str, Union[float, NDArray[np.float_]]]]],
+        problem: Dict[str, List[Dict[str, Union[float, NDArray[np.float32]]]]],
         samples_per_object: int,
         filter_radius: float,
         filter_cull: bool


### PR DESCRIPTION
In the latest `numpy` versions, there is no `float_` type. Just explicitly marking the type as `float32`.