### PR TITLE
Make VAMP usable as a C++ header-only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,90 +45,143 @@ include(CompilerSettings)
 include(FetchInitCPM)
 include(Dependencies)
 
-list(APPEND VAMP_EXT_SOURCES
-  src/impl/vamp/bindings/python.cc
-  src/impl/vamp/bindings/environment.cc
-  src/impl/vamp/bindings/settings.cc
-)
-
-list(APPEND VAMP_ROBOT_MODULES
-  sphere
-  ur5
-  panda
-  fetch
-  baxter
-)
-
-foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
-  list(APPEND VAMP_EXT_SOURCES "src/impl/vamp/bindings/${robot_name}.cc")
-endforeach()
-
-list(APPEND VAMP_EXT_INCLUDES
+list(APPEND VAMP_INCLUDES
   ${NIGH_INCLUDE_DIRS}
   ${PDQSORT_INCLUDE_DIRS}
   src/impl
 )
 
-nanobind_add_module(_core_ext
-    NB_STATIC
-    STABLE_ABI
-    NOMINSIZE
-    ${VAMP_EXT_SOURCES}
+# Header-only C++ library
+include(GNUInstallDirs)
+add_library(vamp INTERFACE)
+target_include_directories(vamp INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/impl>
+  ${NIGH_INCLUDE_DIRS}
+  ${PDQSORT_INCLUDE_DIRS}
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_include_directories(_core_ext
-    SYSTEM PRIVATE
-    ${VAMP_EXT_INCLUDES}
+target_compile_features(vamp INTERFACE cxx_std_17)
+target_link_libraries(vamp INTERFACE Eigen3::Eigen)
+install(TARGETS vamp
+  EXPORT ${PROJECT_NAME}_Targets
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
-target_link_libraries(_core_ext
-    PRIVATE
-    Eigen3::Eigen
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("vampConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
 )
 
-if($ENV{GITHUB_ACTIONS})
-  set(STUB_PREFIX "")
-else()
-  set(STUB_PREFIX "${CMAKE_BINARY_DIR}/stubs/")
-endif()
-
-nanobind_add_stub(
-  vamp_stub
-  MODULE _core_ext
-  OUTPUT "${STUB_PREFIX}__init__.pyi"
-  PYTHON_PATH $<TARGET_FILE_DIR:_core_ext>
-  DEPENDS _core_ext
-  VERBOSE
+configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
 )
 
-foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
+install(EXPORT ${PROJECT_NAME}_Targets
+  FILE ${PROJECT_NAME}Targets.cmake
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+)
+
+install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake
+)
+
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/vamp DESTINATION include)
+
+# Python extension
+option(VAMP_BUILD_PYTHON_BINDINGS "Build Python VAMP extensions" OFF)
+if(VAMP_BUILD_PYTHON_BINDINGS)
+  find_package(Python 3.8
+  REQUIRED COMPONENTS Interpreter Development.Module
+  OPTIONAL_COMPONENTS Development.SABIModule)
+
+  CPMAddPackage("gh:wjakob/nanobind#358d452c314dbe8c07026d984ad8d5aa860f26fb")
+
+  list(APPEND VAMP_EXT_SOURCES
+    src/impl/vamp/bindings/python.cc
+    src/impl/vamp/bindings/environment.cc
+    src/impl/vamp/bindings/settings.cc
+  )
+
+  list(APPEND VAMP_ROBOT_MODULES
+    sphere
+    ur5
+    panda
+    fetch
+    baxter
+  )
+
+  foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
+    list(APPEND VAMP_EXT_SOURCES "src/impl/vamp/bindings/${robot_name}.cc")
+  endforeach()
+
+  nanobind_add_module(_core_ext
+      NB_STATIC
+      STABLE_ABI
+      NOMINSIZE
+      ${VAMP_EXT_SOURCES}
+  )
+
+  target_include_directories(_core_ext
+      SYSTEM PRIVATE
+      ${VAMP_INCLUDES}
+  )
+
+  target_link_libraries(_core_ext
+      PRIVATE
+      Eigen3::Eigen
+  )
+
+  if($ENV{GITHUB_ACTIONS})
+    set(STUB_PREFIX "")
+  else()
+    set(STUB_PREFIX "${CMAKE_BINARY_DIR}/stubs/")
+  endif()
+
   nanobind_add_stub(
-    "vamp_${robot_name}_stub"
-    MODULE "_core_ext.${robot_name}"
-    OUTPUT "${STUB_PREFIX}${robot_name}.pyi"
+    vamp_stub
+    MODULE _core_ext
+    OUTPUT "${STUB_PREFIX}__init__.pyi"
     PYTHON_PATH $<TARGET_FILE_DIR:_core_ext>
     DEPENDS _core_ext
     VERBOSE
   )
-endforeach()
 
-install(
-  TARGETS _core_ext
-  LIBRARY
-  DESTINATION vamp/_core
-)
+  foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
+    nanobind_add_stub(
+      "vamp_${robot_name}_stub"
+      MODULE "_core_ext.${robot_name}"
+      OUTPUT "${STUB_PREFIX}${robot_name}.pyi"
+      PYTHON_PATH $<TARGET_FILE_DIR:_core_ext>
+      DEPENDS _core_ext
+      VERBOSE
+    )
+  endforeach()
 
-install(
-  FILES "${STUB_PREFIX}__init__.pyi"
-  DESTINATION "${CMAKE_SOURCE_DIR}/src/vamp/_core"
-)
-
-foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
   install(
-    FILES "${STUB_PREFIX}${robot_name}.pyi"
+    TARGETS _core_ext
+    LIBRARY
+    DESTINATION vamp/_core
+  )
+
+  install(
+    FILES "${STUB_PREFIX}__init__.pyi"
     DESTINATION "${CMAKE_SOURCE_DIR}/src/vamp/_core"
   )
-endforeach()
+
+  foreach(robot_name IN LISTS VAMP_ROBOT_MODULES)
+    install(
+      FILES "${STUB_PREFIX}${robot_name}.pyi"
+      DESTINATION "${CMAKE_SOURCE_DIR}/src/vamp/_core"
+    )
+  endforeach()
+endif()
 
 if(VAMP_BUILD_OMPL_DEMO)
   find_package(ompl QUIET PATHS ${VAMP_OMPL_PATH})
@@ -136,7 +189,7 @@ if(VAMP_BUILD_OMPL_DEMO)
   if(ompl_FOUND)
     add_executable(vamp_ompl_integration scripts/cpp/ompl_integration.cc)
     target_link_libraries(vamp_ompl_integration PRIVATE ompl::ompl Eigen3::Eigen)
-    target_include_directories(vamp_ompl_integration SYSTEM PRIVATE ${VAMP_EXT_INCLUDES})
+    target_include_directories(vamp_ompl_integration SYSTEM PRIVATE ${VAMP_INCLUDES})
   else()
     message(WARNING "OMPL not found! Cannot build OMPL demo.")
   endif()

--- a/cmake/vampConfig.cmake.in
+++ b/cmake/vampConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,4 @@ cmake.build-type = "Release"
 [tool.scikit-build.cmake.define]
 VAMP_LTO = "ON"
 # VAMP_FORCE_CLANG = "ON"
+VAMP_BUILD_PYTHON_BINDINGS = ON


### PR DESCRIPTION
This PR extends the CMake configuration for VAMP to expose a header-only library of the core implementation, for use in downstream C++ projects.

I have not tested these changes **at all** yet; they are very likely incomplete and/or buggy.
One thing to consider is how much we want to restructure the project to provide more convenience aliases in the headers vs. in the current binding C++ files.
