### PR TITLE
Fix: matrix-vector multiplication for rotation in `Attachment::pose`

### DIFF
--- a/src/impl/vamp/collision/attachments.hh
+++ b/src/impl/vamp/collision/attachments.hh
@@ -114,9 +114,9 @@ namespace vamp::collision
             {
                 const auto &s = spheres[i];
                 // Pose each center
-                const auto s_x = s.x * b_xx + s.x * b_yx + s.x * b_zx + tx;
-                const auto s_y = s.y * b_xy + s.y * b_yy + s.y * b_zy + ty;
-                const auto s_z = s.z * b_xz + s.z * b_yz + s.z * b_zz + tz;
+                const auto s_x = s.x * b_xx + s.y * b_yx + s.z * b_zx + tx;
+                const auto s_y = s.x * b_xy + s.y * b_yy + s.z * b_zy + ty;
+                const auto s_z = s.x * b_xz + s.y * b_yz + s.z * b_zz + tz;
                 posed_spheres[i] = Sphere<DataT>(s_x, s_y, s_z, s.r);
             }
         }


### PR DESCRIPTION
## Description
This PR fixes a bug in `Attachment::pose` located in `./src/impl/vamp/collision/attachments.hh` (lines 117-119). The issue was an incorrect matrix-vector multiplication when updating the positions of `posed_spheres`. The fix ensures proper computation of the rotation for the transform.

## Code Change
**File**: `./src/impl/vamp/collision/attachments.hh`  
**Lines**: 117-119  

**Before:**
```cpp
const auto s_x = s.x * b_xx + s.x * b_yx + s.x * b_zx + tx;
const auto s_y = s.y * b_xy + s.y * b_yy + s.y * b_zy + ty;
const auto s_z = s.z * b_xz + s.z * b_yz + s.z * b_zz + tz;
```

**After:**
```cpp
const auto s_x = s.x * b_xx + s.y * b_yx + s.z * b_zx + tx;
const auto s_y = s.x * b_xy + s.y * b_yy + s.z * b_zy + ty;
const auto s_z = s.x * b_xz + s.y * b_yz + s.z * b_zz + tz;
```

## Testing
Verified that `posed_spheres` rotations now update correctly for various attachment poses. The spheres now track the end-effector's rotation as expected.