### PR TITLE
Fix local Python installation after package renaming for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ Homepage = "https://github.com/KavrakiLab/vamp"
 minimum-version = "0.4"
 build-dir = "build/{wheel_tag}"
 wheel.py-api = "cp312"
+wheel.packages = ["vamp"]
 
 cmake.build-type = "Release"
 


### PR DESCRIPTION
As the title says. Changing the package name was necessary for PyPI uploads to work, but broke local package installation. This PR fixes this issue. After merging, `feat/spot` in #57 should be updated to include this fix.
