### PR TITLE
Allow overriding `VAMP_ARCH` for portable builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ cmake --build build
 ```
 Please see `CMakeLists.txt` for further build configuration options.
 
+#### Architecture-Specific Build Options
+By default, VAMP builds with `-march=native` for optimal performance on the build machine. For builds targeting different hardware (e.g., Docker containers), you can override the architecture flags:
+```bash
+cmake -Bbuild -DCMAKE_BUILD_TYPE=Release -DVAMP_ARCH="-march=x86-64-v3 -mavx2" .
+```
+
+Example options:
+- `-march=x86-64-v3 -mavx2`: Supports most modern x86_64 systems (2013+), includes BMI2 instructions required by VAMP
+- `-march=native -mavx2`: Default setting, optimizes for build machine's specific CPU
+
 ### Docker
 We provide example dockerfiles in `docker/` that show installation on Ubuntu 20.04, 22.04, and 24.04.
 

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -1,15 +1,18 @@
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-	# Need explicit AVX2 for some MacOS clang versions
-	set(VAMP_ARCH "-march=native -mavx2")
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
-	# ARM platforms (aarch64 / arm64)
-	set(VAMP_ARCH "-mcpu=native -mtune=native")
-	# Fix for GCC 13+ NEON vector type conversion errors
-	if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
-		string(APPEND VAMP_ARCH " -flax-vector-conversions")
+# Allow users to override VAMP_ARCH (e.g., for Docker builds targeting different hardware)
+if(NOT DEFINED VAMP_ARCH)
+	if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+		# Need explicit AVX2 for some MacOS clang versions
+		set(VAMP_ARCH "-march=native -mavx2")
+	elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+		# ARM platforms (aarch64 / arm64)
+		set(VAMP_ARCH "-mcpu=native -mtune=native")
+		# Fix for GCC 13+ NEON vector type conversion errors
+		if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+			string(APPEND VAMP_ARCH " -flax-vector-conversions")
+		endif()
+	else()
+		message(FATAL_ERROR "Unsupported architecture ${CMAKE_SYSTEM_PROCESSOR}")
 	endif()
-else()
-	message(FATAL_ERROR "Unsupported architecture ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
 # default fast args that work on all platforms


### PR DESCRIPTION
This change allows users to override the `VAMP_ARCH` variable via CMake. This is useful for Docker builds that need to target different hardware than the build machine.

## Changes
 - Modified `cmake/CompilerSettings.cmake` to only set `VAMP_ARCH` if not already defined
 - Updated `README.md`

## Usage
```bash
  cmake -DVAMP_ARCH="-march=x86-64-v3 -mavx2" ...
```

## Notes
 - Fixes illegal instruction crashes when Docker containers built with `-march=native` run on different CPU architectures
 - Preserves existing behavior when `VAMP_ARCH` is not specified
 - Enables portable builds for containerized environments

## Testing

### Test Environment
 - Ubuntu 22.04, GCC 11.4.0
 - `vamp` commit: `20428ede1879c95f866cea5a2bb5a666c24c5321`

### Test Cases

#### 1. Default Behavior (Backward Compatibility)

```
cmake -B build_default -DCMAKE_BUILD_TYPE=Release .
```
`VAMP_ARCH` correctly set to `-march=native -mavx2` (unchanged from current behavior)

#### 2. Override with Portable Architecture
```
cmake -B build_override -DCMAKE_BUILD_TYPE=Release -DVAMP_ARCH="-march=x86-64-v3 -mavx2" .
```
`VAMP_ARCH` successfully overridden to `-march=x86-64-v3 -mavx2`

#### 3. Verification of Compile Flags

 - Default build flags: `CXX_FLAGS = -march=native -mavx2 -Wall -Wextra -Wno-ignored-attributes -O3 ...`
 - Override build flags: `CXX_FLAGS = -march=x86-64-v3 -mavx2 -Wall -Wextra -Wno-ignored-attributes -O3 ...`

Compiler flags correctly reflect the `VAMP_ARCH` setting in both cases

#### 4. Docker Build Scenario

This change resolved the illegal instruction crashes reported when Docker containers built with `-march=native` run on different hardware architectures.