### PR TITLE
NEON: replace numeric conversion with bit reinterpretation in SIMD log

### DIFF
--- a/src/impl/vamp/vector/neon.hh
+++ b/src/impl/vamp/vector/neon.hh
@@ -622,11 +622,11 @@ namespace vamp
             auto invalid_mask = cmp_less_equal(x, zero_vector());
 
             // cut off denormalized values
-            x = max(x, constant_int(0x00800000));
+            x = max(x, vreinterpretq_f32_u32(vdupq_n_u32(0x00800000u)));
 
             auto emm0 = IntVector::shift_right(as<IntVector::VectorT>(x), 23);
 
-            x = and_(x, constant_int(~0x7f800000));
+            x = and_(x, vreinterpretq_f32_u32(vdupq_n_u32(~0x7f800000u)));
             x = or_(x, half);
 
             // keep only the fractional part


### PR DESCRIPTION
Neon SIMD `log` was clamping via integer->float conversion instead of a bit reinterpretation of `FLT_MIN`, and exponent masking wasn’t purely bitwise. This PR switches to a bit cast and explicit bit masking. 

I noticed this while testing AORRTC: it causes `ProlateHyperspheroidRNG` in AORRTC to produce NaNs, so informed sampling didn’t work as intended. The issue only affects ARM/NEON builds.