### PR TITLE
Viser visualization Example Python

### DIFF
--- a/scripts/viser_utils.py
+++ b/scripts/viser_utils.py
@@ -1,28 +1,30 @@
 from viser.extras import ViserUrdf
 import viser
-import yourdfpy 
+import yourdfpy
 from typing import Sequence, Union
+
 
 def setup_viser_with_robot(robot_dir, robot_urdf_name):
     server = viser.ViserServer()
     # change the robot here
     urdf = yourdfpy.URDF.load(str(robot_dir / robot_urdf_name))
-    robot = ViserUrdf(  
-        server,  
+    robot = ViserUrdf(
+        server,
         urdf,
         load_meshes=True,
         load_collision_meshes=False,
-        root_node_name="/robot"  
+        root_node_name="/robot",
     )
 
     return server, robot
 
+
 def add_spheres(
     server: viser.ViserServer,
     sphere_positions: Sequence,
-    sphere_radii : Sequence,
+    sphere_radii: Sequence,
     colors: Union[Sequence[int], Sequence[Sequence[int]]] = [],
-    prefix: str = 'my_sphere',
+    prefix: str = "my_sphere",
 ):
     """
     Add spheres to the env/
@@ -38,11 +40,12 @@ def add_spheres(
     for i, (sphere_pos, sphere_rad) in enumerate(zip(sphere_positions, sphere_radii)):
         sphere_handles[i] = server.scene.add_icosphere(
             name=f"{prefix}_{i}",
-            radius=sphere_rad,  
+            radius=sphere_rad,
             position=tuple(sphere_pos[:3]),
-            color = tuple(colors[i])
+            color=tuple(colors[i]),
         )
     return sphere_handles
+
 
 def add_trajectory(server, waypoints, robot, attachment_handles, attachment_positions):
     """
@@ -51,7 +54,7 @@ def add_trajectory(server, waypoints, robot, attachment_handles, attachment_posi
 
     Args:
         server (ViserServer): ViserServer instance
-        waypoints (numpy.array): A 2D numpy array (shape: (N,7)) with N waypoints of joint poses 
+        waypoints (numpy.array): A 2D numpy array (shape: (N,7)) with N waypoints of joint poses
         robot (ViserUrdf): ViserUrdf instance of the robot
 
         attachment_handles (numpy.array) - this is a P element list of attachment handles, spheres here
@@ -63,17 +66,14 @@ def add_trajectory(server, waypoints, robot, attachment_handles, attachment_posi
     if len(waypoints) < 1:
         return
     assert len(attachment_handles) == len(attachment_positions[0])
-    traj_slider = server.gui.add_slider(  
-        "Current Waypoint",   
-        min=0,   
-        max=len(waypoints)-1,   
-        step=1,   
-        initial_value=0  
+    traj_slider = server.gui.add_slider(
+        "Current Waypoint", min=0, max=len(waypoints) - 1, step=1, initial_value=0
     )
-    @traj_slider.on_update  
-    def update_robot_pose(event):  
-        waypoint_idx = int(event.target.value)  
-        joint_config = waypoints[waypoint_idx]  
+
+    @traj_slider.on_update
+    def update_robot_pose(event):
+        waypoint_idx = int(event.target.value)
+        joint_config = waypoints[waypoint_idx]
         robot.update_cfg(joint_config)
 
         for attach_idx, attachment_handle in enumerate(attachment_handles):

--- a/scripts/visualize_viser.py
+++ b/scripts/visualize_viser.py
@@ -9,10 +9,10 @@ from fire import Fire
 
 
 # Starting configuration
-a = [0., -0.785, 0., -2.356, 0., 1.571, 0.785]
+a = [0.0, -0.785, 0.0, -2.356, 0.0, 1.571, 0.785]
 
 # Goal configuration
-b = [2.35, 1., 0., -0.8, 0, 2.5, 0.785]
+b = [2.35, 1.0, 0.0, -0.8, 0, 2.5, 0.785]
 
 
 # Problem specification: a list of sphere centers
@@ -31,8 +31,7 @@ problem = [
     [-0.35, -0.35, 0.8],
     [0, -0.55, 0.8],
     [0.35, -0.35, 0.8],
-    ]
-
+]
 
 
 def main(
@@ -41,10 +40,11 @@ def main(
     attachment_offset: float = 0.02,
     planner: str = "rrtc",
     **kwargs,
-    ):
+):
 
-    (vamp_module, planner_func, plan_settings,
-     simp_settings) = vamp.configure_robot_and_planner_with_kwargs("panda", planner, **kwargs)
+    (vamp_module, planner_func, plan_settings, simp_settings) = (
+        vamp.configure_robot_and_planner_with_kwargs("panda", planner, **kwargs)
+    )
 
     # Create an attachment offset on the Z-axis from the end-effector frame
     tf = np.identity(4)
@@ -54,29 +54,30 @@ def main(
     # Add a single sphere to the attachment - spheres are added in the attachment's local frame
     attachment.add_spheres([vamp.Sphere([0, 0, 0], attachment_radius)])
 
-    robot_dir = Path(__file__).parents[1] / 'resources' / 'panda'
+    robot_dir = Path(__file__).parents[1] / "resources" / "panda"
     server, robot = setup_viser_with_robot(robot_dir, "panda_spherized.urdf")
     robot.update_cfg(a)
-
-
 
     e = vamp.Environment()
     for sphere in problem:
         e.add_sphere(vamp.Sphere(sphere, obstacle_radius))
 
-    _problem_sphere_handles = add_spheres(server, np.array(problem), np.array([obstacle_radius] * len(problem)))
+    _problem_sphere_handles = add_spheres(
+        server, np.array(problem), np.array([obstacle_radius] * len(problem))
+    )
 
     # Add the attchment to the VAMP environment
     e.attach(attachment)
     # Add attachment sphere to visualization
-    attachment_sph = add_spheres(server, np.zeros((1, 3)), np.array([attachment_radius]), colors=[[0, 255, 0]])
+    attachment_sph = add_spheres(
+        server, np.zeros((1, 3)), np.array([attachment_radius]), colors=[[0, 255, 0]]
+    )
 
     # Update attachment sphere positions corresponding to the waypoints.
     # this could also be made into a callable that can be called during trajectory viz
     def get_attachment_pos(configuration):
         attachment.set_ee_pose(vamp_module.eefk(configuration))
         return np.array([attachment.posed_spheres[0].position])
-
 
     # Plan and display
     sampler = vamp_module.halton()
@@ -86,7 +87,9 @@ def main(
 
     attachment_positions = [get_attachment_pos(pos) for pos in simple.path.numpy()]
 
-    add_trajectory(server, simple.path.numpy(), robot, attachment_sph, attachment_positions)
+    add_trajectory(
+        server, simple.path.numpy(), robot, attachment_sph, attachment_positions
+    )
 
     # display
     while True:


### PR DESCRIPTION
Pybullet could possibly be too heavy for pure viz purposes. [Viser](https://github.com/nerfstudio-project/viser) provides lightweight 3D visualizations over a web server this is more accessible. 

Simply `pip install viser` and run `python visualize_viser.py` to get started!

Formatted the scripts with [black](https://github.com/psf/black)

Example of visualization in viser with attachment.
![output](https://github.com/user-attachments/assets/c0b48876-069b-4e2c-826f-15100f418742)


