### PR TITLE
fix: pad query radii with point radii before top AABB check in CAPT

### DIFF
--- a/src/impl/vamp/collision/capt.hh
+++ b/src/impl/vamp/collision/capt.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <new>
 #include <numeric>


### PR DESCRIPTION
In CAPTs, point radii are fictitious: their only effect is to pad the radii of spheres used in queries. Previously, the implementation of the CAPT waited until after query spheres had been classified into their leaf cells, then padded the query radii. However, this means that the CAPT could erroneously accept some spheres as non-colliding if they did not intersect the top AABB unless padded by the point radius.

This fixes erroneous acceptances by moving the padding step to the very start of the query procedures for CAPTs.