### PR TITLE
fixed phs sample clamp

### DIFF
--- a/src/impl/vamp/planning/phs.hh
+++ b/src/impl/vamp/planning/phs.hh
@@ -164,7 +164,7 @@ namespace vamp::planning
 
             // Clamp values
             Robot::descale_configuration(x);
-            x=x.clamp(0.F, 1.F);
+            x = x.clamp(0.F, 1.F);
             Robot::scale_configuration(x);
 
             return x;

--- a/src/impl/vamp/planning/phs.hh
+++ b/src/impl/vamp/planning/phs.hh
@@ -164,7 +164,7 @@ namespace vamp::planning
 
             // Clamp values
             Robot::descale_configuration(x);
-            x.clamp(0.F, 1.F);
+            x=x.clamp(0.F, 1.F);
             Robot::scale_configuration(x);
 
             return x;


### PR DESCRIPTION
The current aorrtc does not correctly clamp sampled values, causing the planner to produce paths that violate joint limits. 

**Ex.** for Fetch on bookshelf_tall, aorrtc produced path:
[[ 0.1         1.32        1.4        -0.2         1.72        0.
   1.66        0.        ]
 [ 0.312013    1.0800564   1.3638093  -0.2356756   1.5223789   0.18186502
   1.3956473   0.46751922]
 [ 0.524026    0.8401129   1.3276187  -0.2713512   1.3247577   0.36373004
   1.1312945   0.93503845]
 [ 0.6007637   0.6161268   1.2386806  -0.19828078  1.2444017   0.37947726
   1.0696256   1.0215061 ]
 [ 0.6775013   0.39214063  1.1497425  -0.12521036  1.1640458   0.39522445
   1.0079567   1.1079736 ]
 [ 0.73149335  0.20357451  1.0818026  -0.03826298  1.094518    0.41562477
   0.95212936  1.1978811 ]
 [ 0.7854854   0.0150084   1.0138626   0.0486844   1.02499     0.43602508
   0.89630204  1.2877886 ]
 [ 0.7797412  -0.18502353  0.9829739   0.291964    0.94007456  0.5000914
   0.8138553   1.4848033 ]
 [ 0.77399707 -0.38505548  0.95208514  0.5352436   0.8551592   0.56415766
   0.7314085   1.681818  ]
 [ 0.7491885  -0.3758884   0.9586397   0.61964494  0.86275697  0.5906924
   0.7041613   1.7408653 ]
 [ 0.7243799  -0.3667213   0.9651942   0.7040463   0.87035465  0.6172272
   0.6769141   1.7999127 ]
 [ 0.6274128  -0.27499354  0.9728866   1.0568529   0.94349456  0.7350328
   0.53937864  2.046095  ]
 [ 0.5304457  -0.1832658   0.980579    1.4096596   1.0166345   0.8528384
   0.4018432   2.2922769 ]
 [ 0.45828718 -0.10070515  0.9817169   1.678065    1.0821767   0.9441092
   0.29155493  2.4794116 ]
 [ 0.38612866 -0.0181445   0.9828548   1.9464703   1.147719    1.03538
   0.18126664  2.6665466 ]]

here the first joint of Fetch has a limit of [0, 0.38615]

The above has also been checked by "vamp_module.validate(config_in_path, env, check_bounds=True)" which produced False for some configs in path