### PR TITLE
feat: Convex Polytope Obstacles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+build_test/
 .cache/
 compile_commands.json
 *.out.*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries_system(vamp_cpp
     Eigen3::Eigen
     nigh
     pdqsort
+    cdd
 )
 
 # Link SIMDxorshift if available

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ VAMP fetches the following external dependencies via [CPM](https://github.com/cp
 - [`nigh`](https://github.com/KavrakiLab/nigh): a fork of the original [`nigh`](https://github.com/UNC-Robotics/nigh) [[4]](#4) to better use our vector types
 - [`pdqsort`](https://github.com/orlp/pdqsort): for fast sorting
 - [`SIMDxorshift`](https://github.com/lemire/SIMDxorshift): alternative fast random numbers for x86 machines
+- [`cddlib`](https://github.com/cddlib/cddlib): for convex polytope vertex/halfspace conversion
 
 Download the code:
 ```bash
@@ -114,7 +115,7 @@ pip install .
 ```
 If you want to install all Python dependencies to run the examples, specify those optional dependencies:
 ```bash
-pip install .[examples,heightmaps]
+pip install .[examples,heightmaps,polytopes]
 ```
 If you have installed the `examples` dependencies, test your installation by running:
 ```bash
@@ -295,6 +296,12 @@ These objects can be created with the following:
 - `vamp.Cuboid(center, euler_xyz, half_extents)`: a cuboid specified by the frame and then half-extents (radii) along the X, Y, and Z axes in its local frame.
 - `vamp.Heightfield` via `vamp.make_heightfield` / `vamp.png_to_heightfield`: a heightfield specified by pixel intensity in an image file, scaled over specified dimensions.
 - Pointclouds via `add_pointcloud()` in `vamp.Environment`. This will construct a CAPT from the provided list of points, the minimum and maximum robot sphere radii, and radius for each point in the pointcloud.
+- `vamp.ConvexPolytope`: a convex polytope obstacle defined by halfspace planes and/or vertices. Can be constructed in several ways:
+  - `ConvexPolytope.from_vertices(vertices)`: from a numpy array of vertices
+  - `ConvexPolytope.from_planes(planes)`: from halfspace planes as `List[[nx, ny, nz, d]]` where the interior satisfies `nx*x + ny*y + nz*z <= d`
+  - `ConvexPolytope.from_both(vertices, planes)`: from both representations simultaneously
+  - `vamp.mesh_to_polytopes(filename, position, scale, convex_decomposition, name)`: helper function to load a mesh file and convert it to a list of `ConvexPolytope` obstacles. Supports convex hull or convex decomposition of non-convex meshes. Requires `trimesh`.
+
 See the `src/impl/vamp/collision/` folder for more information.
 
 Some robots (currently, the UR5, Panda, and Fetch) support attaching custom geometry (a collection of spheres) to the end-effector via `vamp.Attachment(relative_position, relative_quaternion_xyzw)`.
@@ -346,7 +353,7 @@ Inside `impl/vamp`, the code is divided into the following directories:
 - [ ] Batch configuration validation
 - [ ] Planning subgroups
 - [X] Object attachment at end-effector
-- [ ] Mesh collision checking
+- [X] Mesh collision checking
 - [X] Pointcloud collision checking
 - [ ] Manifold-constrained planning
 - [ ] Time-optimal trajectory parameterization

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -30,6 +30,42 @@ if(VAMP_INSTALL_CPP_LIBRARY)
   export(EXPORT pdqsort_TARGETS FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/pdqsortTargets.cmake NAMESPACE pdqsort::)
 endif()
 
+# cddlib for convex polytope vertex/halfspace conversion (double description method)
+CPMAddPackage(
+  NAME cddlib
+  GITHUB_REPOSITORY cddlib/cddlib
+  GIT_TAG 0.94m
+)
+
+if(cddlib_SOURCE_DIR)
+  # cddlib uses autotools...
+  add_library(cdd STATIC
+    ${cddlib_SOURCE_DIR}/lib-src/cddcore.c
+    ${cddlib_SOURCE_DIR}/lib-src/cddlp.c
+    ${cddlib_SOURCE_DIR}/lib-src/cddmp.c
+    ${cddlib_SOURCE_DIR}/lib-src/cddio.c
+    ${cddlib_SOURCE_DIR}/lib-src/cddlib.c
+    ${cddlib_SOURCE_DIR}/lib-src/cddproj.c
+    ${cddlib_SOURCE_DIR}/lib-src/setoper.c
+  )
+  target_include_directories(cdd PUBLIC
+    $<BUILD_INTERFACE:${cddlib_SOURCE_DIR}/lib-src>
+  )
+  set_target_properties(cdd PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+  if(VAMP_INSTALL_CPP_LIBRARY)
+    install(TARGETS cdd
+          EXPORT cdd_TARGETS
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(EXPORT cdd_TARGETS FILE cddTargets.cmake NAMESPACE cdd:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cdd)
+    export(EXPORT cdd_TARGETS FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/cddTargets.cmake NAMESPACE cdd::)
+  endif()
+endif()
+
 # SIMDxorshift for x86_64 systems (includes macOS Intel and Linux x86_64)
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
   CPMAddPackage("gh:lemire/SIMDxorshift#857c1a01df53cf1ee1ae8db3238f0ef42ef8e490")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -30,7 +30,7 @@ if(VAMP_INSTALL_CPP_LIBRARY)
   export(EXPORT pdqsort_TARGETS FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/pdqsortTargets.cmake NAMESPACE pdqsort::)
 endif()
 
-# cddlib for convex polytope vertex/halfspace conversion (double description method)
+# cddlib for convex polytope vertex/halfspace conversion
 CPMAddPackage(
   NAME cddlib
   GITHUB_REPOSITORY cddlib/cddlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = ["numpy"]
 [project.optional-dependencies]
 examples = ["fire", "pybullet", "pyyaml", "tqdm", "pandas", "tabulate", "xmltodict"]
 heightmaps = ["pillow"]
+polytopes = ["trimesh", "vhacdx", "scipy"]
 
 [project.urls]
 Homepage = "https://github.com/KavrakiLab/vamp"

--- a/scripts/mesh_test.py
+++ b/scripts/mesh_test.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+import vamp
+from fire import Fire
+
+# Starting configuration
+a = [0., -0.785, 0., -2.356, 0., 1.571, 0.785]
+
+# Goal configuration
+b = [2.35, 1., 0., -0.8, 0, 2.5, 0.785]
+
+
+def main(
+    mesh_file: str = None,
+    position: tuple = (0.5, 0.0, 0.3),
+    scale: float = 2.0,
+    decompose: bool = False,
+    benchmark: bool = True,
+    n_trials: int = 100,
+    visualize: bool = False,
+    planner: str = "rrtc",
+    sampler_name: str = "halton",
+    skip_rng_iterations: int = 0,
+    **kwargs,
+    ):
+
+    if mesh_file is None:
+        mesh_path = Path(__file__).parent.parent / "resources" / "objects" / "Stanford_Bunny.stl"
+    else:
+        mesh_path = Path(mesh_file)
+
+    if not mesh_path.exists():
+        raise FileNotFoundError(f"Mesh file not found: {mesh_path}")
+
+    polytopes = vamp.mesh_to_polytopes(
+        mesh_path, position=position, scale=scale, convex_decomposition=decompose, name="mesh"
+        )
+
+    (vamp_module, planner_func, plan_settings,
+     simp_settings) = vamp.configure_robot_and_planner_with_kwargs("panda", planner, **kwargs)
+
+    sampler = getattr(vamp_module, sampler_name)()
+    sampler.skip(skip_rng_iterations)
+
+    def create_environment():
+        e = vamp.Environment()
+        for polytope in polytopes:
+            e.add_polytope(polytope)
+        return e
+
+    if benchmark:
+        import pandas as pd
+
+        results = []
+        for _ in range(n_trials):
+            e = create_environment()
+
+            if vamp.panda.validate(a, e) and vamp.panda.validate(b, e):
+                result = planner_func(a, b, e, plan_settings, sampler)
+                simple = vamp_module.simplify(result.path, e, simp_settings, sampler)
+                results.append(vamp.results_to_dict(result, simple))
+
+        df = pd.DataFrame.from_dict(results)
+
+        # Convert to microseconds
+        df["planning_time"] = df["planning_time"].dt.microseconds
+        df["simplification_time"] = df["simplification_time"].dt.microseconds
+
+        # Get summary statistics
+        stats = df[[
+            "planning_time",
+            "simplification_time",
+            "initial_path_cost",
+            "simplified_path_cost",
+            "planning_iterations"
+            ]].describe()
+
+        print(stats)
+
+    if visualize:
+        from vamp import pybullet_interface as vpb
+
+        robot_dir = Path(__file__).parent.parent / 'resources' / 'panda'
+        sim = vpb.PyBulletSimulator(str(robot_dir / f"panda_spherized.urdf"), vamp_module.joint_names(), True)
+
+        e = create_environment()
+        for polytope in polytopes:
+            sim.add_polytope(polytope)
+
+        result = planner_func(a, b, e, plan_settings, sampler)
+        simple = vamp_module.simplify(result.path, e, simp_settings, sampler)
+
+        simple.path.interpolate_to_resolution(vamp.panda.resolution())
+
+        sim.animate(simple.path)
+
+
+if __name__ == "__main__":
+    Fire(main)

--- a/scripts/mesh_test.py
+++ b/scripts/mesh_test.py
@@ -14,6 +14,7 @@ def main(
     position: tuple = (0.5, 0.0, 0.0),
     scale: float = 0.01,
     decompose: bool = False,
+    max_convex_hulls: int = 10,
     benchmark: bool = False,
     n_trials: int = 100,
     visualize: bool = True,
@@ -32,7 +33,12 @@ def main(
         raise FileNotFoundError(f"Mesh file not found: {mesh_path}")
 
     polytopes = vamp.mesh_to_polytopes(
-        mesh_path, position=position, scale=scale, convex_decomposition=decompose, name="mesh"
+        mesh_path,
+        position = position,
+        scale = scale,
+        convex_decomposition = decompose,
+        name = "mesh",
+        maxConvexHulls = max_convex_hulls
         )
 
     (vamp_module, planner_func, plan_settings,

--- a/scripts/mesh_test.py
+++ b/scripts/mesh_test.py
@@ -3,20 +3,20 @@ import vamp
 from fire import Fire
 
 # Starting configuration
-a = [0., -0.785, 0., -2.356, 0., 1.571, 0.785]
+a = [-1., 1., 0., -0.8, 0, 2.5, 0.785]
 
 # Goal configuration
-b = [2.35, 1., 0., -0.8, 0, 2.5, 0.785]
+b = [1., 1., 0., -0.8, 0, 2.5, 0.785]
 
 
 def main(
     mesh_file: str = None,
-    position: tuple = (0.5, 0.0, 0.3),
-    scale: float = 2.0,
+    position: tuple = (0.5, 0.0, 0.0),
+    scale: float = 0.01,
     decompose: bool = False,
-    benchmark: bool = True,
+    benchmark: bool = False,
     n_trials: int = 100,
-    visualize: bool = False,
+    visualize: bool = True,
     planner: str = "rrtc",
     sampler_name: str = "halton",
     skip_rng_iterations: int = 0,

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -179,48 +179,47 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "add_sphere",
             [](vc::Environment<float> &e, const vc::Sphere<float> &s)
             {
-        e.spheres.emplace_back(s);
-        e.sort();
+                e.spheres.emplace_back(s);
+                e.sort();
             })
         .def(
             "add_cuboid",
             [](vc::Environment<float> &e, const vc::Cuboid<float> &s)
             {
-        if (s.axis_3_z == 1.)
-        {
-            e.z_aligned_cuboids.emplace_back(s);
-        }
-        else
-        {
-            e.cuboids.emplace_back(s);
-        }
-        e.sort();
+                if (s.axis_3_z == 1.)
+                {
+                    e.z_aligned_cuboids.emplace_back(s);
+                }
+                else
+                {
+                    e.cuboids.emplace_back(s);
+                }
+                e.sort();
             })
         .def(
             "add_capsule",
             [](vc::Environment<float> &e, const vc::Cylinder<float> &s)
             {
-        if (s.xv == 0. and s.yv == 0.)
-        {
-            e.z_aligned_capsules.emplace_back(s);
-        }
-        else
-        {
-            e.capsules.emplace_back(s);
-        }
-        e.sort();
+                if (s.xv == 0. and s.yv == 0.)
+                {
+                    e.z_aligned_capsules.emplace_back(s);
+                }
+                else
+                {
+                    e.capsules.emplace_back(s);
+                }
+                e.sort();
             })
         .def(
             "add_heightfield",
             [](vc::Environment<float> &e, const vc::HeightField<float> &s)
-            {
-        e.heightfields.emplace_back(s); })
+            { e.heightfields.emplace_back(s); })
         .def(
             "add_polytope",
             [](vc::Environment<float> &e, const vc::ConvexPolytope<float> &p)
             {
-        e.polytopes.emplace_back(p);
-        e.sort();
+                e.polytopes.emplace_back(p);
+                e.sort();
             })
         .def(
             "add_pointcloud",
@@ -230,16 +229,14 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
                float r_max,
                float r_point)
             {
-        auto start_time = std::chrono::steady_clock::now();
-        e.pointclouds.emplace_back(pc, r_min, r_max, r_point);
-        return vamp::utils::get_elapsed_nanoseconds(start_time);
+                auto start_time = std::chrono::steady_clock::now();
+                e.pointclouds.emplace_back(pc, r_min, r_max, r_point);
+                return vamp::utils::get_elapsed_nanoseconds(start_time);
             })
         .def(
             "attach",
-            [](vc::Environment<float> &e, const vc::Attachment<float> &a) {
-        e.attachments.emplace(a); })
-        .def("detach", [](vc::Environment<float> &e) {
-        e.attachments.reset(); });
+            [](vc::Environment<float> &e, const vc::Attachment<float> &a) { e.attachments.emplace(a); })
+        .def("detach", [](vc::Environment<float> &e) { e.attachments.reset(); });
 
     pymodule.def(
         "filter_pointcloud",
@@ -251,10 +248,10 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
            const collision::Point &workcell_max,
            bool cull) -> std::pair<std::vector<collision::Point>, std::size_t>
         {
-        auto start_time = std::chrono::steady_clock::now();
-        auto filtered =
-            vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
-        return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
+            auto start_time = std::chrono::steady_clock::now();
+            auto filtered =
+                vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
+            return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
         });
 
     pymodule.def(
@@ -267,10 +264,10 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
            const collision::Point &workcell_max,
            bool cull) -> std::pair<std::vector<collision::Point>, std::size_t>
         {
-        auto start_time = std::chrono::steady_clock::now();
-        auto filtered =
-            vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
-        return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
+            auto start_time = std::chrono::steady_clock::now();
+            auto filtered =
+                vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
+            return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
         });
 
     nb::class_<vc::Attachment<float>>(pymodule, "Attachment")
@@ -278,30 +275,27 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "__init__",
             [](vc::Attachment<float> *q, Eigen::Matrix4f &tf) noexcept
             {
-        Eigen::Isometry3f iso;
-        iso.matrix() = tf;
-        new (q) vc::Attachment<float>(iso);
+                Eigen::Isometry3f iso;
+                iso.matrix() = tf;
+                new (q) vc::Attachment<float>(iso);
             },
             "Constructor for an attachment centered at a relative transform from the end-effector.")
-        .def_prop_ro("relative_frame", [](vc::Attachment<float> &a) {
-        return a.tf; })
+        .def_prop_ro("relative_frame", [](vc::Attachment<float> &a) { return a.tf; })
         .def(
             "add_sphere",
             [](vc::Attachment<float> &a, collision::Sphere<float> &sphere)
-            {
-        a.spheres.emplace_back(sphere); })
+            { a.spheres.emplace_back(sphere); })
         .def(
             "add_spheres",
             [](vc::Attachment<float> &a, std::vector<collision::Sphere<float>> &spheres)
-            {
-        a.spheres.insert(a.spheres.end(), spheres.cbegin(), spheres.cend()); })
+            { a.spheres.insert(a.spheres.end(), spheres.cbegin(), spheres.cend()); })
         .def(
             "set_ee_pose",
             [](vc::Attachment<float> &a, Eigen::Matrix4f &tf)
             {
-        Eigen::Isometry3f iso;
-        iso.matrix() = tf;
-        a.pose(iso);
+                Eigen::Isometry3f iso;
+                iso.matrix() = tf;
+                a.pose(iso);
             },
             "tf"_a)
         .def_ro("posed_spheres", &vc::Attachment<float>::posed_spheres);

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -110,58 +110,58 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
         .def(
             "__init__",
             [](vc::ConvexPolytope<float> *q, const std::vector<std::array<float, 4>> &planes)
-            { new (q) vc::ConvexPolytope<float>(vf::polytope::from_planes(planes)); },
+            {
+        new (q) vc::ConvexPolytope<float>(vf::polytope::from_planes(planes)); },
             "planes"_a,
-            "Constructor from halfplanes as List[[nx, ny, nz, d]] where n.x <= d. "
-            "Vertices are computed automatically.")
+            "Constructor from halfplanes as List[[nx, ny, nz, d]]."
         .def(
             "__init__",
             [](vc::ConvexPolytope<float> *q,
                const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
             {
-                std::vector<float> vx, vy, vz;
-                const std::size_t num_vertices = vertices.shape(0);
-                vx.reserve(num_vertices);
-                vy.reserve(num_vertices);
-                vz.reserve(num_vertices);
+        std::vector<float> vx, vy, vz;
+        const std::size_t num_vertices = vertices.shape(0);
+        vx.reserve(num_vertices);
+        vy.reserve(num_vertices);
+        vz.reserve(num_vertices);
 
-                for (std::size_t i = 0; i < num_vertices; ++i)
-                {
-                    vx.push_back(vertices(i, 0));
-                    vy.push_back(vertices(i, 1));
-                    vz.push_back(vertices(i, 2));
-                }
+        for (std::size_t i = 0; i < num_vertices; ++i)
+        {
+            vx.push_back(vertices(i, 0));
+            vy.push_back(vertices(i, 1));
+            vz.push_back(vertices(i, 2));
+        }
 
-                new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
+        new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
             },
             "vertices"_a,
-            "Constructor from Nx3 vertices array. Computes convex hull and halfplanes automatically.")
+            "Constructor from vertices array.")
         .def_static(
             "from_planes",
             &vf::polytope::from_planes,
             "planes"_a,
-            "Create from halfplanes as List[[nx, ny, nz, d]] where n.x <= d.")
+            "Create from halfplanes as List[[nx, ny, nz, d]].")
         .def_static(
             "from_vertices",
             [](const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
             {
-                std::vector<float> vx, vy, vz;
-                const std::size_t num_vertices = vertices.shape(0);
-                vx.reserve(num_vertices);
-                vy.reserve(num_vertices);
-                vz.reserve(num_vertices);
+        std::vector<float> vx, vy, vz;
+        const std::size_t num_vertices = vertices.shape(0);
+        vx.reserve(num_vertices);
+        vy.reserve(num_vertices);
+        vz.reserve(num_vertices);
 
-                for (std::size_t i = 0; i < num_vertices; ++i)
-                {
-                    vx.push_back(vertices(i, 0));
-                    vy.push_back(vertices(i, 1));
-                    vz.push_back(vertices(i, 2));
-                }
+        for (std::size_t i = 0; i < num_vertices; ++i)
+        {
+            vx.push_back(vertices(i, 0));
+            vy.push_back(vertices(i, 1));
+            vz.push_back(vertices(i, 2));
+        }
 
-                return vf::polytope::from_vertices(vx, vy, vz);
+        return vf::polytope::from_vertices(vx, vy, vz);
             },
             "vertices"_a,
-            "Create from Nx3 vertices array. Computes convex hull and halfplanes.")
+            "Create from vertices array.")
         .def_ro("num_planes", &vc::ConvexPolytope<float>::num_planes)
         .def_ro("nx", &vc::ConvexPolytope<float>::nx)
         .def_ro("ny", &vc::ConvexPolytope<float>::ny)
@@ -180,47 +180,48 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "add_sphere",
             [](vc::Environment<float> &e, const vc::Sphere<float> &s)
             {
-                e.spheres.emplace_back(s);
-                e.sort();
+        e.spheres.emplace_back(s);
+        e.sort();
             })
         .def(
             "add_cuboid",
             [](vc::Environment<float> &e, const vc::Cuboid<float> &s)
             {
-                if (s.axis_3_z == 1.)
-                {
-                    e.z_aligned_cuboids.emplace_back(s);
-                }
-                else
-                {
-                    e.cuboids.emplace_back(s);
-                }
-                e.sort();
+        if (s.axis_3_z == 1.)
+        {
+            e.z_aligned_cuboids.emplace_back(s);
+        }
+        else
+        {
+            e.cuboids.emplace_back(s);
+        }
+        e.sort();
             })
         .def(
             "add_capsule",
             [](vc::Environment<float> &e, const vc::Cylinder<float> &s)
             {
-                if (s.xv == 0. and s.yv == 0.)
-                {
-                    e.z_aligned_capsules.emplace_back(s);
-                }
-                else
-                {
-                    e.capsules.emplace_back(s);
-                }
-                e.sort();
+        if (s.xv == 0. and s.yv == 0.)
+        {
+            e.z_aligned_capsules.emplace_back(s);
+        }
+        else
+        {
+            e.capsules.emplace_back(s);
+        }
+        e.sort();
             })
         .def(
             "add_heightfield",
             [](vc::Environment<float> &e, const vc::HeightField<float> &s)
-            { e.heightfields.emplace_back(s); })
+            {
+        e.heightfields.emplace_back(s); })
         .def(
             "add_polytope",
             [](vc::Environment<float> &e, const vc::ConvexPolytope<float> &p)
             {
-                e.polytopes.emplace_back(p);
-                e.sort();
+        e.polytopes.emplace_back(p);
+        e.sort();
             })
         .def(
             "add_pointcloud",
@@ -230,14 +231,16 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
                float r_max,
                float r_point)
             {
-                auto start_time = std::chrono::steady_clock::now();
-                e.pointclouds.emplace_back(pc, r_min, r_max, r_point);
-                return vamp::utils::get_elapsed_nanoseconds(start_time);
+        auto start_time = std::chrono::steady_clock::now();
+        e.pointclouds.emplace_back(pc, r_min, r_max, r_point);
+        return vamp::utils::get_elapsed_nanoseconds(start_time);
             })
         .def(
             "attach",
-            [](vc::Environment<float> &e, const vc::Attachment<float> &a) { e.attachments.emplace(a); })
-        .def("detach", [](vc::Environment<float> &e) { e.attachments.reset(); });
+            [](vc::Environment<float> &e, const vc::Attachment<float> &a) {
+        e.attachments.emplace(a); })
+        .def("detach", [](vc::Environment<float> &e) {
+        e.attachments.reset(); });
 
     pymodule.def(
         "filter_pointcloud",
@@ -249,10 +252,10 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
            const collision::Point &workcell_max,
            bool cull) -> std::pair<std::vector<collision::Point>, std::size_t>
         {
-            auto start_time = std::chrono::steady_clock::now();
-            auto filtered =
-                vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
-            return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
+        auto start_time = std::chrono::steady_clock::now();
+        auto filtered =
+            vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
+        return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
         });
 
     pymodule.def(
@@ -265,10 +268,10 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
            const collision::Point &workcell_max,
            bool cull) -> std::pair<std::vector<collision::Point>, std::size_t>
         {
-            auto start_time = std::chrono::steady_clock::now();
-            auto filtered =
-                vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
-            return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
+        auto start_time = std::chrono::steady_clock::now();
+        auto filtered =
+            vc::filter_pointcloud(pc, min_dist, max_range, origin, workcell_min, workcell_max, cull);
+        return {filtered, vamp::utils::get_elapsed_nanoseconds(start_time)};
         });
 
     nb::class_<vc::Attachment<float>>(pymodule, "Attachment")
@@ -276,27 +279,30 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "__init__",
             [](vc::Attachment<float> *q, Eigen::Matrix4f &tf) noexcept
             {
-                Eigen::Isometry3f iso;
-                iso.matrix() = tf;
-                new (q) vc::Attachment<float>(iso);
+        Eigen::Isometry3f iso;
+        iso.matrix() = tf;
+        new (q) vc::Attachment<float>(iso);
             },
             "Constructor for an attachment centered at a relative transform from the end-effector.")
-        .def_prop_ro("relative_frame", [](vc::Attachment<float> &a) { return a.tf; })
+        .def_prop_ro("relative_frame", [](vc::Attachment<float> &a) {
+        return a.tf; })
         .def(
             "add_sphere",
             [](vc::Attachment<float> &a, collision::Sphere<float> &sphere)
-            { a.spheres.emplace_back(sphere); })
+            {
+        a.spheres.emplace_back(sphere); })
         .def(
             "add_spheres",
             [](vc::Attachment<float> &a, std::vector<collision::Sphere<float>> &spheres)
-            { a.spheres.insert(a.spheres.end(), spheres.cbegin(), spheres.cend()); })
+            {
+        a.spheres.insert(a.spheres.end(), spheres.cbegin(), spheres.cend()); })
         .def(
             "set_ee_pose",
             [](vc::Attachment<float> &a, Eigen::Matrix4f &tf)
             {
-                Eigen::Isometry3f iso;
-                iso.matrix() = tf;
-                a.pose(iso);
+        Eigen::Isometry3f iso;
+        iso.matrix() = tf;
+        a.pose(iso);
             },
             "tf"_a)
         .def_ro("posed_spheres", &vc::Attachment<float>::posed_spheres);

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -180,7 +180,8 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
 
                 for (auto i = 0U; i < num_planes; ++i)
                 {
-                    plns.emplace_back(std::array<float, 4>{planes(i, 0), planes(i, 1), planes(i, 2), planes(i, 3)});
+                    plns.emplace_back(
+                        std::array<float, 4>{planes(i, 0), planes(i, 1), planes(i, 2), planes(i, 3)});
                 }
 
                 return vf::polytope::from_both(verts, plns);

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -126,9 +126,9 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
 
                 for (std::size_t i = 0; i < num_vertices; ++i)
                 {
-                    vx.push_back(vertices(i, 0));
-                    vy.push_back(vertices(i, 1));
-                    vz.push_back(vertices(i, 2));
+                    vx.emplace_back(vertices(i, 0));
+                    vy.emplace_back(vertices(i, 1));
+                    vz.emplace_back(vertices(i, 2));
                 }
 
                 new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
@@ -152,15 +152,42 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
 
                 for (std::size_t i = 0; i < num_vertices; ++i)
                 {
-                    vx.push_back(vertices(i, 0));
-                    vy.push_back(vertices(i, 1));
-                    vz.push_back(vertices(i, 2));
+                    vx.emplace_back(vertices(i, 0));
+                    vy.emplace_back(vertices(i, 1));
+                    vz.emplace_back(vertices(i, 2));
                 }
 
                 return vf::polytope::from_vertices(vx, vy, vz);
             },
             "vertices"_a,
             "Create from vertices array.")
+        .def_static(
+            "from_both",
+            [](const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices,
+               const nb::ndarray<float, nb::shape<-1, 4>, nb::device::cpu> &planes)
+            {
+                std::vector<std::array<float, 3>> verts;
+                std::vector<std::array<float, 4>> plns;
+                const std::size_t num_vertices = vertices.shape(0);
+                const std::size_t num_planes = planes.shape(0);
+                verts.reserve(num_vertices);
+                plns.reserve(num_planes);
+
+                for (auto i = 0U; i < num_vertices; ++i)
+                {
+                    verts.emplace_back(std::array<float, 3>{vertices(i, 0), vertices(i, 1), vertices(i, 2)});
+                }
+
+                for (auto i = 0U; i < num_planes; ++i)
+                {
+                    plns.emplace_back(std::array<float, 4>{planes(i, 0), planes(i, 1), planes(i, 2), planes(i, 3)});
+                }
+
+                return vf::polytope::from_both(verts, plns);
+            },
+            "vertices"_a,
+            "planes"_a,
+            "Create from both vertices array and planes array.")
         .def_ro("num_planes", &vc::ConvexPolytope<float>::num_planes)
         .def_ro("nx", &vc::ConvexPolytope<float>::nx)
         .def_ro("ny", &vc::ConvexPolytope<float>::ny)

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -106,6 +106,74 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
         .def_ro("zs", &vc::HeightField<float>::zs)
         .def_ro("data", &vc::HeightField<float>::data);
 
+    nb::class_<vc::ConvexPolytope<float>>(pymodule, "ConvexPolytope")
+        .def(
+            "__init__",
+            [](vc::ConvexPolytope<float> *q, const std::vector<std::array<float, 4>> &planes)
+            { new (q) vc::ConvexPolytope<float>(vf::polytope::from_planes(planes)); },
+            "planes"_a,
+            "Constructor from halfplanes as List[[nx, ny, nz, d]] where n.x <= d. "
+            "Vertices are computed automatically.")
+        .def(
+            "__init__",
+            [](vc::ConvexPolytope<float> *q,
+               const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
+            {
+                std::vector<float> vx, vy, vz;
+                const std::size_t num_vertices = vertices.shape(0);
+                vx.reserve(num_vertices);
+                vy.reserve(num_vertices);
+                vz.reserve(num_vertices);
+
+                for (std::size_t i = 0; i < num_vertices; ++i)
+                {
+                    vx.push_back(vertices(i, 0));
+                    vy.push_back(vertices(i, 1));
+                    vz.push_back(vertices(i, 2));
+                }
+
+                new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
+            },
+            "vertices"_a,
+            "Constructor from Nx3 vertices array. Computes convex hull and halfplanes automatically.")
+        .def_static(
+            "from_planes",
+            &vf::polytope::from_planes,
+            "planes"_a,
+            "Create from halfplanes as List[[nx, ny, nz, d]] where n.x <= d.")
+        .def_static(
+            "from_vertices",
+            [](const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
+            {
+                std::vector<float> vx, vy, vz;
+                const std::size_t num_vertices = vertices.shape(0);
+                vx.reserve(num_vertices);
+                vy.reserve(num_vertices);
+                vz.reserve(num_vertices);
+
+                for (std::size_t i = 0; i < num_vertices; ++i)
+                {
+                    vx.push_back(vertices(i, 0));
+                    vy.push_back(vertices(i, 1));
+                    vz.push_back(vertices(i, 2));
+                }
+
+                return vf::polytope::from_vertices(vx, vy, vz);
+            },
+            "vertices"_a,
+            "Create from Nx3 vertices array. Computes convex hull and halfplanes.")
+        .def_ro("num_planes", &vc::ConvexPolytope<float>::num_planes)
+        .def_ro("nx", &vc::ConvexPolytope<float>::nx)
+        .def_ro("ny", &vc::ConvexPolytope<float>::ny)
+        .def_ro("nz", &vc::ConvexPolytope<float>::nz)
+        .def_ro("d", &vc::ConvexPolytope<float>::d)
+        .def_ro("num_vertices", &vc::ConvexPolytope<float>::num_vertices)
+        .def_ro("vx", &vc::ConvexPolytope<float>::vx)
+        .def_ro("vy", &vc::ConvexPolytope<float>::vy)
+        .def_ro("vz", &vc::ConvexPolytope<float>::vz)
+        .def_ro("min_distance", &vc::ConvexPolytope<float>::min_distance)
+        .def_rw("name", &vc::ConvexPolytope<float>::name);
+
     nb::class_<vc::Environment<float>>(pymodule, "Environment")
         .def(nb::init<>())
         .def(
@@ -147,6 +215,13 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "add_heightfield",
             [](vc::Environment<float> &e, const vc::HeightField<float> &s)
             { e.heightfields.emplace_back(s); })
+        .def(
+            "add_polytope",
+            [](vc::Environment<float> &e, const vc::ConvexPolytope<float> &p)
+            {
+                e.polytopes.emplace_back(p);
+                e.sort();
+            })
         .def(
             "add_pointcloud",
             [](vc::Environment<float> &e,

--- a/src/impl/vamp/bindings/environment.cc
+++ b/src/impl/vamp/bindings/environment.cc
@@ -110,29 +110,28 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
         .def(
             "__init__",
             [](vc::ConvexPolytope<float> *q, const std::vector<std::array<float, 4>> &planes)
-            {
-        new (q) vc::ConvexPolytope<float>(vf::polytope::from_planes(planes)); },
+            { new (q) vc::ConvexPolytope<float>(vf::polytope::from_planes(planes)); },
             "planes"_a,
-            "Constructor from halfplanes as List[[nx, ny, nz, d]]."
+            "Constructor from halfplanes as [nx, ny, nz, d].")
         .def(
             "__init__",
             [](vc::ConvexPolytope<float> *q,
                const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
             {
-        std::vector<float> vx, vy, vz;
-        const std::size_t num_vertices = vertices.shape(0);
-        vx.reserve(num_vertices);
-        vy.reserve(num_vertices);
-        vz.reserve(num_vertices);
+                std::vector<float> vx, vy, vz;
+                const std::size_t num_vertices = vertices.shape(0);
+                vx.reserve(num_vertices);
+                vy.reserve(num_vertices);
+                vz.reserve(num_vertices);
 
-        for (std::size_t i = 0; i < num_vertices; ++i)
-        {
-            vx.push_back(vertices(i, 0));
-            vy.push_back(vertices(i, 1));
-            vz.push_back(vertices(i, 2));
-        }
+                for (std::size_t i = 0; i < num_vertices; ++i)
+                {
+                    vx.push_back(vertices(i, 0));
+                    vy.push_back(vertices(i, 1));
+                    vz.push_back(vertices(i, 2));
+                }
 
-        new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
+                new (q) vc::ConvexPolytope<float>(vf::polytope::from_vertices(vx, vy, vz));
             },
             "vertices"_a,
             "Constructor from vertices array.")
@@ -145,20 +144,20 @@ void vamp::binding::init_environment(nanobind::module_ &pymodule)
             "from_vertices",
             [](const nb::ndarray<float, nb::shape<-1, 3>, nb::device::cpu> &vertices)
             {
-        std::vector<float> vx, vy, vz;
-        const std::size_t num_vertices = vertices.shape(0);
-        vx.reserve(num_vertices);
-        vy.reserve(num_vertices);
-        vz.reserve(num_vertices);
+                std::vector<float> vx, vy, vz;
+                const std::size_t num_vertices = vertices.shape(0);
+                vx.reserve(num_vertices);
+                vy.reserve(num_vertices);
+                vz.reserve(num_vertices);
 
-        for (std::size_t i = 0; i < num_vertices; ++i)
-        {
-            vx.push_back(vertices(i, 0));
-            vy.push_back(vertices(i, 1));
-            vz.push_back(vertices(i, 2));
-        }
+                for (std::size_t i = 0; i < num_vertices; ++i)
+                {
+                    vx.push_back(vertices(i, 0));
+                    vy.push_back(vertices(i, 1));
+                    vz.push_back(vertices(i, 2));
+                }
 
-        return vf::polytope::from_vertices(vx, vy, vz);
+                return vf::polytope::from_vertices(vx, vy, vz);
             },
             "vertices"_a,
             "Create from vertices array.")

--- a/src/impl/vamp/collision/environment.hh
+++ b/src/impl/vamp/collision/environment.hh
@@ -21,6 +21,7 @@ namespace vamp::collision
         std::vector<Cuboid<DataT>> cuboids;
         std::vector<Cuboid<DataT>> z_aligned_cuboids;
         std::vector<HeightField<DataT>> heightfields;
+        std::vector<ConvexPolytope<DataT>> polytopes;
         std::vector<CAPT> pointclouds;
         std::optional<Attachment<DataT>> attachments;
 
@@ -35,6 +36,7 @@ namespace vamp::collision
           , cuboids(other.cuboids.begin(), other.cuboids.end())
           , z_aligned_cuboids(other.z_aligned_cuboids.begin(), other.z_aligned_cuboids.end())
           , heightfields(other.heightfields.begin(), other.heightfields.end())
+          , polytopes(other.polytopes.begin(), other.polytopes.end())
           , pointclouds(other.pointclouds.begin(), other.pointclouds.end())
           , attachments(other.template clone_attachments<DataT>())
         {
@@ -65,6 +67,10 @@ namespace vamp::collision
             std::sort(
                 z_aligned_cuboids.begin(),
                 z_aligned_cuboids.end(),
+                [](const auto &a, const auto &b) { return a.min_distance < b.min_distance; });
+            std::sort(
+                polytopes.begin(),
+                polytopes.end(),
                 [](const auto &a, const auto &b) { return a.min_distance < b.min_distance; });
         }
 

--- a/src/impl/vamp/collision/factory.hh
+++ b/src/impl/vamp/collision/factory.hh
@@ -428,7 +428,6 @@ namespace vamp::collision::factory
         // Construct a convex polytope from arrays of plane coefficients
         // Each plane is defined as nx*x + ny*y + nz*z <= d
         // Normals should be unit vectors pointing outward from the polytope interior
-        // Vertices are computed automatically via cddlib
         inline static auto flat(
             const std::vector<float> &nx,
             const std::vector<float> &ny,
@@ -437,35 +436,19 @@ namespace vamp::collision::factory
         {
             auto data = collision::halfspaces_to_vertices(nx, ny, nz, d);
             return collision::ConvexPolytope<float>(
-                data.nx.size(),
-                data.nx,
-                data.ny,
-                data.nz,
-                data.d,
-                data.vx.size(),
-                data.vx,
-                data.vy,
-                data.vz);
+                data.nx.size(), data.nx, data.ny, data.nz, data.d, data.vx.size(), data.vx, data.vy, data.vz);
         }
 
-        // Construct from a vector of 4-tuples (nx, ny, nz, d) - computes vertices via cddlib
+        // Construct from a vector of halfspaces
         inline static auto from_planes(const std::vector<std::array<float, 4>> &planes)
             -> collision::ConvexPolytope<float>
         {
             auto data = collision::halfspaces_to_vertices(planes);
             return collision::ConvexPolytope<float>(
-                data.nx.size(),
-                data.nx,
-                data.ny,
-                data.nz,
-                data.d,
-                data.vx.size(),
-                data.vx,
-                data.vy,
-                data.vz);
+                data.nx.size(), data.nx, data.ny, data.nz, data.d, data.vx.size(), data.vx, data.vy, data.vz);
         }
 
-        // Construct from SoA vertex coordinates - computes halfspaces via cddlib
+        // Construct from vertices
         inline static auto from_vertices(
             const std::vector<float> &vx,
             const std::vector<float> &vy,
@@ -473,35 +456,19 @@ namespace vamp::collision::factory
         {
             auto data = collision::vertices_to_halfspaces(vx, vy, vz);
             return collision::ConvexPolytope<float>(
-                data.nx.size(),
-                data.nx,
-                data.ny,
-                data.nz,
-                data.d,
-                data.vx.size(),
-                data.vx,
-                data.vy,
-                data.vz);
+                data.nx.size(), data.nx, data.ny, data.nz, data.d, data.vx.size(), data.vx, data.vy, data.vz);
         }
 
-        // Construct from a vector of 3-tuples (x, y, z) vertices - computes halfspaces via cddlib
+        // Construct from a vector of vertices
         inline static auto from_vertices(const std::vector<std::array<float, 3>> &vertices)
             -> collision::ConvexPolytope<float>
         {
             auto data = collision::vertices_to_halfspaces(vertices);
             return collision::ConvexPolytope<float>(
-                data.nx.size(),
-                data.nx,
-                data.ny,
-                data.nz,
-                data.d,
-                data.vx.size(),
-                data.vx,
-                data.vy,
-                data.vz);
+                data.nx.size(), data.nx, data.ny, data.nz, data.d, data.vx.size(), data.vx, data.vy, data.vz);
         }
 
-        // Construct from both representations (no conversion needed)
+        // Construct from both representations
         inline static auto from_both(
             const std::vector<std::array<float, 3>> &vertices,
             const std::vector<std::array<float, 4>> &planes) noexcept -> collision::ConvexPolytope<float>

--- a/src/impl/vamp/collision/factory.hh
+++ b/src/impl/vamp/collision/factory.hh
@@ -6,6 +6,7 @@
 #include <vamp/collision/shapes.hh>
 #include <vamp/collision/environment.hh>
 #include <vamp/collision/math.hh>
+#include <vamp/collision/polytope_convert.hh>
 
 #include <Eigen/Dense>
 
@@ -421,4 +422,118 @@ namespace vamp::collision::factory
                 data);
         }
     }  // namespace heightfield
+
+    namespace polytope
+    {
+        // Construct a convex polytope from arrays of plane coefficients
+        // Each plane is defined as nx*x + ny*y + nz*z <= d
+        // Normals should be unit vectors pointing outward from the polytope interior
+        // Vertices are computed automatically via cddlib
+        inline static auto flat(
+            const std::vector<float> &nx,
+            const std::vector<float> &ny,
+            const std::vector<float> &nz,
+            const std::vector<float> &d) -> collision::ConvexPolytope<float>
+        {
+            auto data = collision::halfspaces_to_vertices(nx, ny, nz, d);
+            return collision::ConvexPolytope<float>(
+                data.nx.size(),
+                data.nx,
+                data.ny,
+                data.nz,
+                data.d,
+                data.vx.size(),
+                data.vx,
+                data.vy,
+                data.vz);
+        }
+
+        // Construct from a vector of 4-tuples (nx, ny, nz, d) - computes vertices via cddlib
+        inline static auto from_planes(const std::vector<std::array<float, 4>> &planes)
+            -> collision::ConvexPolytope<float>
+        {
+            auto data = collision::halfspaces_to_vertices(planes);
+            return collision::ConvexPolytope<float>(
+                data.nx.size(),
+                data.nx,
+                data.ny,
+                data.nz,
+                data.d,
+                data.vx.size(),
+                data.vx,
+                data.vy,
+                data.vz);
+        }
+
+        // Construct from SoA vertex coordinates - computes halfspaces via cddlib
+        inline static auto from_vertices(
+            const std::vector<float> &vx,
+            const std::vector<float> &vy,
+            const std::vector<float> &vz) -> collision::ConvexPolytope<float>
+        {
+            auto data = collision::vertices_to_halfspaces(vx, vy, vz);
+            return collision::ConvexPolytope<float>(
+                data.nx.size(),
+                data.nx,
+                data.ny,
+                data.nz,
+                data.d,
+                data.vx.size(),
+                data.vx,
+                data.vy,
+                data.vz);
+        }
+
+        // Construct from a vector of 3-tuples (x, y, z) vertices - computes halfspaces via cddlib
+        inline static auto from_vertices(const std::vector<std::array<float, 3>> &vertices)
+            -> collision::ConvexPolytope<float>
+        {
+            auto data = collision::vertices_to_halfspaces(vertices);
+            return collision::ConvexPolytope<float>(
+                data.nx.size(),
+                data.nx,
+                data.ny,
+                data.nz,
+                data.d,
+                data.vx.size(),
+                data.vx,
+                data.vy,
+                data.vz);
+        }
+
+        // Construct from both representations (no conversion needed)
+        inline static auto from_both(
+            const std::vector<std::array<float, 3>> &vertices,
+            const std::vector<std::array<float, 4>> &planes) noexcept -> collision::ConvexPolytope<float>
+        {
+            std::vector<float> nx, ny, nz, d;
+            nx.reserve(planes.size());
+            ny.reserve(planes.size());
+            nz.reserve(planes.size());
+            d.reserve(planes.size());
+
+            for (const auto &plane : planes)
+            {
+                nx.emplace_back(plane[0]);
+                ny.emplace_back(plane[1]);
+                nz.emplace_back(plane[2]);
+                d.emplace_back(plane[3]);
+            }
+
+            std::vector<float> vx, vy, vz;
+            vx.reserve(vertices.size());
+            vy.reserve(vertices.size());
+            vz.reserve(vertices.size());
+
+            for (const auto &v : vertices)
+            {
+                vx.emplace_back(v[0]);
+                vy.emplace_back(v[1]);
+                vz.emplace_back(v[2]);
+            }
+
+            return collision::ConvexPolytope<float>(
+                planes.size(), nx, ny, nz, d, vertices.size(), vx, vy, vz);
+        }
+    }  // namespace polytope
 }  // namespace vamp::collision::factory

--- a/src/impl/vamp/collision/polytope_convert.hh
+++ b/src/impl/vamp/collision/polytope_convert.hh
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <vector>
+#include <array>
+#include <stdexcept>
+#include <cmath>
+
+extern "C"
+{
+#include <setoper.h>
+#include <cdd.h>
+}
+
+namespace vamp::collision
+{
+    struct PolytopeData
+    {
+        std::vector<float> nx, ny, nz, d;
+        std::vector<float> vx, vy, vz;
+    };
+
+    inline void cdd_init()
+    {
+        static bool initialized = false;
+        if (!initialized)
+        {
+            dd_set_global_constants();
+            initialized = true;
+        }
+    }
+
+    inline auto vertices_to_halfspaces(
+        const std::vector<float> &vx,
+        const std::vector<float> &vy,
+        const std::vector<float> &vz) -> PolytopeData
+    {
+        cdd_init();
+
+        const std::size_t num_vertices = vx.size();
+        if (num_vertices < 4)
+        {
+            throw std::invalid_argument("Need at least 4 vertices for a 3D convex polytope");
+        }
+
+        PolytopeData result;
+        result.vx = vx;
+        result.vy = vy;
+        result.vz = vz;
+
+        // Each row is [1, x, y, z] for a vertex (1 indicates vertex, not ray)
+        dd_MatrixPtr vertices_matrix = dd_CreateMatrix(num_vertices, 4);
+        vertices_matrix->representation = dd_Generator;
+        vertices_matrix->numbtype = dd_Real;
+
+        for (auto i = 0U; i < num_vertices; ++i)
+        {
+            dd_set_d(vertices_matrix->matrix[i][0], 1.0);
+            dd_set_d(vertices_matrix->matrix[i][1], static_cast<double>(vx[i]));
+            dd_set_d(vertices_matrix->matrix[i][2], static_cast<double>(vy[i]));
+            dd_set_d(vertices_matrix->matrix[i][3], static_cast<double>(vz[i]));
+        }
+
+        dd_ErrorType err = dd_NoError;
+        dd_PolyhedraPtr poly = dd_DDMatrix2Poly(vertices_matrix, &err);
+
+        if (err != dd_NoError || poly == nullptr)
+        {
+            dd_FreeMatrix(vertices_matrix);
+            if (poly)
+                dd_FreePolyhedra(poly);
+            throw std::runtime_error("cddlib: Failed to convert vertices to halfspaces");
+        }
+
+        dd_MatrixPtr inequalities = dd_CopyInequalities(poly);
+
+        result.nx.reserve(inequalities->rowsize);
+        result.ny.reserve(inequalities->rowsize);
+        result.nz.reserve(inequalities->rowsize);
+        result.d.reserve(inequalities->rowsize);
+
+        for (dd_rowrange i = 0; i < inequalities->rowsize; ++i)
+        {
+            // cddlib format: b + a1*x1 + a2*x2 + a3*x3 >= 0
+            // We want: nx*x + ny*y + nz*z <= d
+            // So: -a1*x - a2*y - a3*z <= b
+            double b = dd_get_d(inequalities->matrix[i][0]);
+            double a1 = dd_get_d(inequalities->matrix[i][1]);
+            double a2 = dd_get_d(inequalities->matrix[i][2]);
+            double a3 = dd_get_d(inequalities->matrix[i][3]);
+
+            // Normalize the plane equation
+            double norm = std::sqrt(a1 * a1 + a2 * a2 + a3 * a3);
+            if (norm > 1e-10)
+            {
+                result.nx.push_back(static_cast<float>(-a1 / norm));
+                result.ny.push_back(static_cast<float>(-a2 / norm));
+                result.nz.push_back(static_cast<float>(-a3 / norm));
+                result.d.push_back(static_cast<float>(b / norm));
+            }
+        }
+
+        dd_FreeMatrix(inequalities);
+        dd_FreePolyhedra(poly);
+        dd_FreeMatrix(vertices_matrix);
+
+        return result;
+    }
+
+    inline auto halfspaces_to_vertices(
+        const std::vector<float> &nx,
+        const std::vector<float> &ny,
+        const std::vector<float> &nz,
+        const std::vector<float> &d) -> PolytopeData
+    {
+        cdd_init();
+
+        const std::size_t num_planes = nx.size();
+        if (num_planes < 4)
+        {
+            throw std::invalid_argument("Need at least 4 halfspaces for a bounded 3D polytope");
+        }
+
+        PolytopeData result;
+        result.nx = nx;
+        result.ny = ny;
+        result.nz = nz;
+        result.d = d;
+
+        dd_MatrixPtr ineq_matrix = dd_CreateMatrix(num_planes, 4);
+        ineq_matrix->representation = dd_Inequality;
+        ineq_matrix->numbtype = dd_Real;
+
+        for (std::size_t i = 0; i < num_planes; ++i)
+        {
+            dd_set_d(ineq_matrix->matrix[i][0], static_cast<double>(d[i]));
+            dd_set_d(ineq_matrix->matrix[i][1], static_cast<double>(-nx[i]));
+            dd_set_d(ineq_matrix->matrix[i][2], static_cast<double>(-ny[i]));
+            dd_set_d(ineq_matrix->matrix[i][3], static_cast<double>(-nz[i]));
+        }
+
+        dd_ErrorType err = dd_NoError;
+        dd_PolyhedraPtr poly = dd_DDMatrix2Poly(ineq_matrix, &err);
+
+        if (err != dd_NoError || poly == nullptr)
+        {
+            dd_FreeMatrix(ineq_matrix);
+            if (poly)
+                dd_FreePolyhedra(poly);
+            throw std::runtime_error("cddlib: Failed to convert halfspaces to vertices");
+        }
+
+        dd_MatrixPtr generators = dd_CopyGenerators(poly);
+
+        result.vx.reserve(generators->rowsize);
+        result.vy.reserve(generators->rowsize);
+        result.vz.reserve(generators->rowsize);
+
+        for (dd_rowrange i = 0; i < generators->rowsize; ++i)
+        {
+            double type = dd_get_d(generators->matrix[i][0]);
+            if (type > 0.5)
+            {
+                result.vx.push_back(static_cast<float>(dd_get_d(generators->matrix[i][1])));
+                result.vy.push_back(static_cast<float>(dd_get_d(generators->matrix[i][2])));
+                result.vz.push_back(static_cast<float>(dd_get_d(generators->matrix[i][3])));
+            }
+        }
+
+        dd_FreeMatrix(generators);
+        dd_FreePolyhedra(poly);
+        dd_FreeMatrix(ineq_matrix);
+
+        return result;
+    }
+
+    inline auto vertices_to_halfspaces(const std::vector<std::array<float, 3>> &vertices) -> PolytopeData
+    {
+        std::vector<float> vx, vy, vz;
+        vx.reserve(vertices.size());
+        vy.reserve(vertices.size());
+        vz.reserve(vertices.size());
+
+        for (const auto &v : vertices)
+        {
+            vx.push_back(v[0]);
+            vy.push_back(v[1]);
+            vz.push_back(v[2]);
+        }
+
+        return vertices_to_halfspaces(vx, vy, vz);
+    }
+
+    inline auto halfspaces_to_vertices(const std::vector<std::array<float, 4>> &planes) -> PolytopeData
+    {
+        std::vector<float> nx, ny, nz, d;
+        nx.reserve(planes.size());
+        ny.reserve(planes.size());
+        nz.reserve(planes.size());
+        d.reserve(planes.size());
+
+        for (const auto &p : planes)
+        {
+            nx.push_back(p[0]);
+            ny.push_back(p[1]);
+            nz.push_back(p[2]);
+            d.push_back(p[3]);
+        }
+
+        return halfspaces_to_vertices(nx, ny, nz, d);
+    }
+
+}  // namespace vamp::collision

--- a/src/impl/vamp/collision/polytope_convert.hh
+++ b/src/impl/vamp/collision/polytope_convert.hh
@@ -22,7 +22,7 @@ namespace vamp::collision
     inline void cdd_init()
     {
         static bool initialized = false;
-        if (!initialized)
+        if (not initialized)
         {
             dd_set_global_constants();
             initialized = true;
@@ -63,7 +63,7 @@ namespace vamp::collision
         dd_ErrorType err = dd_NoError;
         dd_PolyhedraPtr poly = dd_DDMatrix2Poly(vertices_matrix, &err);
 
-        if (err != dd_NoError || poly == nullptr)
+        if (err != dd_NoError or poly == nullptr)
         {
             dd_FreeMatrix(vertices_matrix);
             if (poly)
@@ -94,10 +94,10 @@ namespace vamp::collision
             double norm = std::sqrt(a1 * a1 + a2 * a2 + a3 * a3);
             if (norm > 1e-10)
             {
-                result.nx.push_back(static_cast<float>(-a1 / norm));
-                result.ny.push_back(static_cast<float>(-a2 / norm));
-                result.nz.push_back(static_cast<float>(-a3 / norm));
-                result.d.push_back(static_cast<float>(b / norm));
+                result.nx.emplace_back(static_cast<float>(-a1 / norm));
+                result.ny.emplace_back(static_cast<float>(-a2 / norm));
+                result.nz.emplace_back(static_cast<float>(-a3 / norm));
+                result.d.emplace_back(static_cast<float>(b / norm));
             }
         }
 
@@ -164,9 +164,9 @@ namespace vamp::collision
             double type = dd_get_d(generators->matrix[i][0]);
             if (type > 0.5)
             {
-                result.vx.push_back(static_cast<float>(dd_get_d(generators->matrix[i][1])));
-                result.vy.push_back(static_cast<float>(dd_get_d(generators->matrix[i][2])));
-                result.vz.push_back(static_cast<float>(dd_get_d(generators->matrix[i][3])));
+                result.vx.emplace_back(static_cast<float>(dd_get_d(generators->matrix[i][1])));
+                result.vy.emplace_back(static_cast<float>(dd_get_d(generators->matrix[i][2])));
+                result.vz.emplace_back(static_cast<float>(dd_get_d(generators->matrix[i][3])));
             }
         }
 
@@ -186,9 +186,9 @@ namespace vamp::collision
 
         for (const auto &v : vertices)
         {
-            vx.push_back(v[0]);
-            vy.push_back(v[1]);
-            vz.push_back(v[2]);
+            vx.emplace_back(v[0]);
+            vy.emplace_back(v[1]);
+            vz.emplace_back(v[2]);
         }
 
         return vertices_to_halfspaces(vx, vy, vz);
@@ -204,10 +204,10 @@ namespace vamp::collision
 
         for (const auto &p : planes)
         {
-            nx.push_back(p[0]);
-            ny.push_back(p[1]);
-            nz.push_back(p[2]);
-            d.push_back(p[3]);
+            nx.emplace_back(p[0]);
+            ny.emplace_back(p[1]);
+            nz.emplace_back(p[2]);
+            d.emplace_back(p[3]);
         }
 
         return halfspaces_to_vertices(nx, ny, nz, d);

--- a/src/impl/vamp/collision/polytope_convert.hh
+++ b/src/impl/vamp/collision/polytope_convert.hh
@@ -67,7 +67,9 @@ namespace vamp::collision
         {
             dd_FreeMatrix(vertices_matrix);
             if (poly)
+            {
                 dd_FreePolyhedra(poly);
+            }
             throw std::runtime_error("cddlib: Failed to convert vertices to halfspaces");
         }
 
@@ -145,7 +147,9 @@ namespace vamp::collision
         {
             dd_FreeMatrix(ineq_matrix);
             if (poly)
+            {
                 dd_FreePolyhedra(poly);
+            }
             throw std::runtime_error("cddlib: Failed to convert halfspaces to vertices");
         }
 

--- a/src/impl/vamp/collision/shapes.hh
+++ b/src/impl/vamp/collision/shapes.hh
@@ -9,6 +9,7 @@
 #include <vamp/vector.hh>
 #include <vamp/collision/math.hh>
 
+#include <Eigen/Dense>
 #include <Eigen/Geometry>
 
 namespace vamp::collision
@@ -333,8 +334,8 @@ namespace vamp::collision
         std::vector<float> vy;
         std::vector<float> vz;
 
-        // Axis-aligned bounding box for fast collision pre-check
-        Cuboid<DataT> aabb;
+        // Oriented bounding box for fast collision pre-check
+        Cuboid<DataT> obb;
 
         ConvexPolytope() = default;
 
@@ -359,7 +360,7 @@ namespace vamp::collision
           , vy(vy)
           , vz(vz)
         {
-            aabb = compute_aabb();
+            obb = compute_obb();
             Shape<DataT>::min_distance = compute_min_distance();
         }
 
@@ -372,39 +373,89 @@ namespace vamp::collision
                 float dist = std::sqrt(vx[i] * vx[i] + vy[i] * vy[i] + vz[i] * vz[i]);
                 min_dist = std::min(min_dist, dist);
             }
+
             return DataT(min_dist);
         }
 
-        inline auto compute_aabb() -> Cuboid<DataT>
+        inline auto compute_obb() -> Cuboid<DataT>
         {
-            float min_x = vx[0], max_x = vx[0];
-            float min_y = vy[0], max_y = vy[0];
-            float min_z = vz[0], max_z = vz[0];
-
-            for (auto i = 1U; i < num_vertices; ++i)
+            float cx = 0, cy = 0, cz = 0;
+            for (auto i = 0U; i < num_vertices; ++i)
             {
-                min_x = std::min(min_x, vx[i]);
-                max_x = std::max(max_x, vx[i]);
-                min_y = std::min(min_y, vy[i]);
-                max_y = std::max(max_y, vy[i]);
-                min_z = std::min(min_z, vz[i]);
-                max_z = std::max(max_z, vz[i]);
+                cx += vx[i];
+                cy += vy[i];
+                cz += vz[i];
+            }
+            cx /= num_vertices;
+            cy /= num_vertices;
+            cz /= num_vertices;
+
+            Eigen::Matrix3f cov = Eigen::Matrix3f::Zero();
+            for (auto i = 0U; i < num_vertices; ++i)
+            {
+                const float dx = vx[i] - cx;
+                const float dy = vy[i] - cy;
+                const float dz = vz[i] - cz;
+                cov(0, 0) += dx * dx;
+                cov(0, 1) += dx * dy;
+                cov(0, 2) += dx * dz;
+                cov(1, 1) += dy * dy;
+                cov(1, 2) += dy * dz;
+                cov(2, 2) += dz * dz;
+            }
+            cov(1, 0) = cov(0, 1);
+            cov(2, 0) = cov(0, 2);
+            cov(2, 1) = cov(1, 2);
+
+            Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> solver(cov);
+            Eigen::Matrix3f axes = solver.eigenvectors();
+
+            if (axes.determinant() < 0)
+            {
+                axes.col(0) *= -1;
             }
 
-            // Center and half-extents
-            float cx = (min_x + max_x) * 0.5f;
-            float cy = (min_y + max_y) * 0.5f;
-            float cz = (min_z + max_z) * 0.5f;
-            float hx = (max_x - min_x) * 0.5f;
-            float hy = (max_y - min_y) * 0.5f;
-            float hz = (max_z - min_z) * 0.5f;
+            float min_0 = std::numeric_limits<float>::max();
+            float max_0 = std::numeric_limits<float>::lowest();
+            float min_1 = std::numeric_limits<float>::max();
+            float max_1 = std::numeric_limits<float>::lowest();
+            float min_2 = std::numeric_limits<float>::max();
+            float max_2 = std::numeric_limits<float>::lowest();
+
+            const Eigen::Vector3f axis_0 = axes.col(0);
+            const Eigen::Vector3f axis_1 = axes.col(1);
+            const Eigen::Vector3f axis_2 = axes.col(2);
+
+            for (auto i = 0U; i < num_vertices; ++i)
+            {
+                const Eigen::Vector3f v(vx[i], vy[i], vz[i]);
+                const float proj_0 = v.dot(axis_0);
+                const float proj_1 = v.dot(axis_1);
+                const float proj_2 = v.dot(axis_2);
+
+                min_0 = std::min(min_0, proj_0);
+                max_0 = std::max(max_0, proj_0);
+                min_1 = std::min(min_1, proj_1);
+                max_1 = std::max(max_1, proj_1);
+                min_2 = std::min(min_2, proj_2);
+                max_2 = std::max(max_2, proj_2);
+            }
+
+            const float mid_0 = (min_0 + max_0) * 0.5f;
+            const float mid_1 = (min_1 + max_1) * 0.5f;
+            const float mid_2 = (min_2 + max_2) * 0.5f;
+            Eigen::Vector3f center = mid_0 * axis_0 + mid_1 * axis_1 + mid_2 * axis_2;
+
+            const float half_0 = (max_0 - min_0) * 0.5f;
+            const float half_1 = (max_1 - min_1) * 0.5f;
+            const float half_2 = (max_2 - min_2) * 0.5f;
 
             return Cuboid<DataT>(
-                DataT(cx), DataT(cy), DataT(cz),
-                DataT(1), DataT(0), DataT(0),
-                DataT(0), DataT(1), DataT(0),
-                DataT(0), DataT(0), DataT(1),
-                DataT(hx), DataT(hy), DataT(hz));
+                DataT(center.x()), DataT(center.y()), DataT(center.z()),
+                DataT(axis_0.x()), DataT(axis_0.y()), DataT(axis_0.z()),
+                DataT(axis_1.x()), DataT(axis_1.y()), DataT(axis_1.z()),
+                DataT(axis_2.x()), DataT(axis_2.y()), DataT(axis_2.z()),
+                DataT(half_0), DataT(half_1), DataT(half_2));
         }
 
         template <typename OtherDataT>
@@ -419,7 +470,7 @@ namespace vamp::collision
           , vx(other.vx)
           , vy(other.vy)
           , vz(other.vz)
-          , aabb(other.aabb)
+          , obb(other.obb)
         {
             for (auto i = 0U; i < other.nx.size(); ++i)
             {

--- a/src/impl/vamp/collision/shapes.hh
+++ b/src/impl/vamp/collision/shapes.hh
@@ -316,25 +316,25 @@ namespace vamp::collision
     };
 
     // A convex polytope with dual representation:
-    // - H-representation: F half-planes 
-    // - V-representation: V vertices 
+    // - H-representation: half-planes
+    // - V-representation: vertices
     template <typename DataT>
     struct ConvexPolytope : public Shape<DataT>
     {
-        // H-representation: halfspaces
+        // Halfspaces
         std::size_t num_planes;
         std::vector<DataT> nx;  // plane normals
         std::vector<DataT> ny;
         std::vector<DataT> nz;
-        std::vector<DataT> d;   // plane offsets (n.x <= d defines interior)
+        std::vector<DataT> d;  // plane offsets (n.x <= d defines interior)
 
-        // V-representation: vertices
+        // Vertices
         std::size_t num_vertices;
         std::vector<float> vx;
         std::vector<float> vy;
         std::vector<float> vz;
 
-        // Oriented bounding box for fast collision pre-check
+        // Oriented bounding box for broadphase
         Cuboid<DataT> obb;
 
         ConvexPolytope() = default;
@@ -451,11 +451,21 @@ namespace vamp::collision
             const float half_2 = (max_2 - min_2) * 0.5f;
 
             return Cuboid<DataT>(
-                DataT(center.x()), DataT(center.y()), DataT(center.z()),
-                DataT(axis_0.x()), DataT(axis_0.y()), DataT(axis_0.z()),
-                DataT(axis_1.x()), DataT(axis_1.y()), DataT(axis_1.z()),
-                DataT(axis_2.x()), DataT(axis_2.y()), DataT(axis_2.z()),
-                DataT(half_0), DataT(half_1), DataT(half_2));
+                DataT(center.x()),
+                DataT(center.y()),
+                DataT(center.z()),
+                DataT(axis_0.x()),
+                DataT(axis_0.y()),
+                DataT(axis_0.z()),
+                DataT(axis_1.x()),
+                DataT(axis_1.y()),
+                DataT(axis_1.z()),
+                DataT(axis_2.x()),
+                DataT(axis_2.y()),
+                DataT(axis_2.z()),
+                DataT(half_0),
+                DataT(half_1),
+                DataT(half_2));
         }
 
         template <typename OtherDataT>

--- a/src/impl/vamp/collision/shapes.hh
+++ b/src/impl/vamp/collision/shapes.hh
@@ -315,18 +315,17 @@ namespace vamp::collision
     };
 
     // A convex polytope with dual representation:
-    // - H-representation: F half-planes { x : n_i . x <= d_i }
-    // - V-representation: V vertices defining the convex hull
-    // Storage: SoA layout with separate vectors for each component
+    // - H-representation: F half-planes 
+    // - V-representation: V vertices 
     template <typename DataT>
     struct ConvexPolytope : public Shape<DataT>
     {
         // H-representation: halfspaces
         std::size_t num_planes;
-        std::vector<float> nx;  // plane normals
-        std::vector<float> ny;
-        std::vector<float> nz;
-        std::vector<float> d;   // plane offsets (n.x <= d defines interior)
+        std::vector<DataT> nx;  // plane normals
+        std::vector<DataT> ny;
+        std::vector<DataT> nz;
+        std::vector<DataT> d;   // plane offsets (n.x <= d defines interior)
 
         // V-representation: vertices
         std::size_t num_vertices;
@@ -334,15 +333,17 @@ namespace vamp::collision
         std::vector<float> vy;
         std::vector<float> vz;
 
+        // Axis-aligned bounding box for fast collision pre-check
+        Cuboid<DataT> aabb;
+
         ConvexPolytope() = default;
 
-        // Constructor from both representations (V and H)
         explicit ConvexPolytope(
             std::size_t num_planes,
-            const std::vector<float> &nx,
-            const std::vector<float> &ny,
-            const std::vector<float> &nz,
-            const std::vector<float> &d,
+            const std::vector<DataT> &nx,
+            const std::vector<DataT> &ny,
+            const std::vector<DataT> &nz,
+            const std::vector<DataT> &d,
             std::size_t num_vertices,
             const std::vector<float> &vx,
             const std::vector<float> &vy,
@@ -358,6 +359,7 @@ namespace vamp::collision
           , vy(vy)
           , vz(vz)
         {
+            aabb = compute_aabb();
             Shape<DataT>::min_distance = compute_min_distance();
         }
 
@@ -373,19 +375,59 @@ namespace vamp::collision
             return DataT(min_dist);
         }
 
+        inline auto compute_aabb() -> Cuboid<DataT>
+        {
+            float min_x = vx[0], max_x = vx[0];
+            float min_y = vy[0], max_y = vy[0];
+            float min_z = vz[0], max_z = vz[0];
+
+            for (auto i = 1U; i < num_vertices; ++i)
+            {
+                min_x = std::min(min_x, vx[i]);
+                max_x = std::max(max_x, vx[i]);
+                min_y = std::min(min_y, vy[i]);
+                max_y = std::max(max_y, vy[i]);
+                min_z = std::min(min_z, vz[i]);
+                max_z = std::max(max_z, vz[i]);
+            }
+
+            // Center and half-extents
+            float cx = (min_x + max_x) * 0.5f;
+            float cy = (min_y + max_y) * 0.5f;
+            float cz = (min_z + max_z) * 0.5f;
+            float hx = (max_x - min_x) * 0.5f;
+            float hy = (max_y - min_y) * 0.5f;
+            float hz = (max_z - min_z) * 0.5f;
+
+            return Cuboid<DataT>(
+                DataT(cx), DataT(cy), DataT(cz),
+                DataT(1), DataT(0), DataT(0),
+                DataT(0), DataT(1), DataT(0),
+                DataT(0), DataT(0), DataT(1),
+                DataT(hx), DataT(hy), DataT(hz));
+        }
+
         template <typename OtherDataT>
         explicit ConvexPolytope(const ConvexPolytope<OtherDataT> &other)
           : Shape<DataT>(other)
           , num_planes(other.num_planes)
-          , nx(other.nx)
-          , ny(other.ny)
-          , nz(other.nz)
-          , d(other.d)
+          , nx(other.nx.size())
+          , ny(other.ny.size())
+          , nz(other.nz.size())
+          , d(other.d.size())
           , num_vertices(other.num_vertices)
           , vx(other.vx)
           , vy(other.vy)
           , vz(other.vz)
+          , aabb(other.aabb)
         {
+            for (auto i = 0U; i < other.nx.size(); ++i)
+            {
+                nx[i] = DataT(other.nx[i]);
+                ny[i] = DataT(other.ny[i]);
+                nz[i] = DataT(other.nz[i]);
+                d[i] = DataT(other.d[i]);
+            }
         }
     };
 }  // namespace vamp::collision

--- a/src/impl/vamp/collision/shapes.hh
+++ b/src/impl/vamp/collision/shapes.hh
@@ -2,6 +2,9 @@
 
 #include <string>
 #include <memory>
+#include <vector>
+#include <limits>
+#include <cmath>
 
 #include <vamp/vector.hh>
 #include <vamp/collision/math.hh>
@@ -307,6 +310,81 @@ namespace vamp::collision
           , xd2(other.xd2)
           , yd2(other.yd2)
           , data(other.data)
+        {
+        }
+    };
+
+    // A convex polytope with dual representation:
+    // - H-representation: F half-planes { x : n_i . x <= d_i }
+    // - V-representation: V vertices defining the convex hull
+    // Storage: SoA layout with separate vectors for each component
+    template <typename DataT>
+    struct ConvexPolytope : public Shape<DataT>
+    {
+        // H-representation: halfspaces
+        std::size_t num_planes;
+        std::vector<float> nx;  // plane normals
+        std::vector<float> ny;
+        std::vector<float> nz;
+        std::vector<float> d;   // plane offsets (n.x <= d defines interior)
+
+        // V-representation: vertices
+        std::size_t num_vertices;
+        std::vector<float> vx;
+        std::vector<float> vy;
+        std::vector<float> vz;
+
+        ConvexPolytope() = default;
+
+        // Constructor from both representations (V and H)
+        explicit ConvexPolytope(
+            std::size_t num_planes,
+            const std::vector<float> &nx,
+            const std::vector<float> &ny,
+            const std::vector<float> &nz,
+            const std::vector<float> &d,
+            std::size_t num_vertices,
+            const std::vector<float> &vx,
+            const std::vector<float> &vy,
+            const std::vector<float> &vz)
+          : Shape<DataT>()
+          , num_planes(num_planes)
+          , nx(nx)
+          , ny(ny)
+          , nz(nz)
+          , d(d)
+          , num_vertices(num_vertices)
+          , vx(vx)
+          , vy(vy)
+          , vz(vz)
+        {
+            Shape<DataT>::min_distance = compute_min_distance();
+        }
+
+        inline auto compute_min_distance() -> DataT
+        {
+            // Minimum distance from origin to any vertex
+            float min_dist = std::numeric_limits<float>::max();
+            for (auto i = 0U; i < num_vertices; ++i)
+            {
+                float dist = std::sqrt(vx[i] * vx[i] + vy[i] * vy[i] + vz[i] * vz[i]);
+                min_dist = std::min(min_dist, dist);
+            }
+            return DataT(min_dist);
+        }
+
+        template <typename OtherDataT>
+        explicit ConvexPolytope(const ConvexPolytope<OtherDataT> &other)
+          : Shape<DataT>(other)
+          , num_planes(other.num_planes)
+          , nx(other.nx)
+          , ny(other.ny)
+          , nz(other.nz)
+          , d(other.d)
+          , num_vertices(other.num_vertices)
+          , vx(other.vx)
+          , vy(other.vy)
+          , vz(other.vz)
         {
         }
     };

--- a/src/impl/vamp/collision/sphere_polytope.hh
+++ b/src/impl/vamp/collision/sphere_polytope.hh
@@ -43,9 +43,7 @@ namespace vamp::collision
     }
 
     template <typename DataT>
-    inline auto sphere_polytope(
-        const ConvexPolytope<DataT> &p,
-        const Sphere<DataT> &s) noexcept -> DataT
+    inline auto sphere_polytope(const ConvexPolytope<DataT> &p, const Sphere<DataT> &s) noexcept -> DataT
     {
         return sphere_polytope(p, s.x, s.y, s.z, s.r);
     }

--- a/src/impl/vamp/collision/sphere_polytope.hh
+++ b/src/impl/vamp/collision/sphere_polytope.hh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <vamp/collision/shapes.hh>
+#include <vamp/collision/math.hh>
+
+#include <limits>
+
+namespace vamp::collision
+{
+    // Sphere-polytope collision: returns negative if collision
+    // Algorithm: find max signed distance across all planes
+    // If max > 0, separating plane exists (no collision)
+    template <typename DataT>
+    inline auto sphere_polytope(
+        const ConvexPolytope<DataT> &p,
+        const DataT &cx,
+        const DataT &cy,
+        const DataT &cz,
+        const DataT &r) noexcept -> DataT
+    {
+        DataT max_dist = DataT::fill(-std::numeric_limits<float>::max());
+
+        for (auto i = 0U; i < p.num_planes; ++i)
+        {
+            auto nx_i = DataT::fill(p.nx[i]);
+            auto ny_i = DataT::fill(p.ny[i]);
+            auto nz_i = DataT::fill(p.nz[i]);
+            auto d_i = DataT::fill(p.d[i]);
+
+            // dist = n.C - d - r (positive = separated)
+            auto dist = dot_3(nx_i, ny_i, nz_i, cx, cy, cz) - d_i - r;
+            max_dist = max_dist.max(dist);
+
+            // Early out: if all spheres are already separated, skip remaining planes
+            if (max_dist.test_zero())
+            {
+                break;
+            }
+        }
+
+        // Convention: negative = collision, non-negative = no collision
+        // max_dist > 0 means separating plane exists (no collision)
+        // max_dist <= 0 means all planes satisfied (collision)
+        return max_dist;
+    }
+
+    template <typename DataT>
+    inline auto sphere_polytope(
+        const ConvexPolytope<DataT> &p,
+        const Sphere<DataT> &s) noexcept -> DataT
+    {
+        return sphere_polytope(p, s.x, s.y, s.z, s.r);
+    }
+}  // namespace vamp::collision

--- a/src/impl/vamp/collision/sphere_polytope.hh
+++ b/src/impl/vamp/collision/sphere_polytope.hh
@@ -2,6 +2,7 @@
 
 #include <vamp/collision/shapes.hh>
 #include <vamp/collision/math.hh>
+#include <vamp/collision/sphere_cuboid.hh>
 
 #include <limits>
 
@@ -18,29 +19,29 @@ namespace vamp::collision
         const DataT &cz,
         const DataT &r) noexcept -> DataT
     {
+        const auto rsq = r * r;
+        auto aabb_dist = sphere_cuboid(p.aabb, cx, cy, cz, rsq);
+
+        if (aabb_dist.test_zero())
+        {
+            return aabb_dist;
+        }
+
         DataT max_dist = DataT::fill(-std::numeric_limits<float>::max());
 
+        // TODO: Proper GJK...
         for (auto i = 0U; i < p.num_planes; ++i)
         {
-            auto nx_i = DataT::fill(p.nx[i]);
-            auto ny_i = DataT::fill(p.ny[i]);
-            auto nz_i = DataT::fill(p.nz[i]);
-            auto d_i = DataT::fill(p.d[i]);
-
             // dist = n.C - d - r (positive = separated)
-            auto dist = dot_3(nx_i, ny_i, nz_i, cx, cy, cz) - d_i - r;
+            auto dist = dot_3(p.nx[i], p.ny[i], p.nz[i], cx, cy, cz) - p.d[i] - r;
             max_dist = max_dist.max(dist);
 
-            // Early out: if all spheres are already separated, skip remaining planes
             if (max_dist.test_zero())
             {
                 break;
             }
         }
 
-        // Convention: negative = collision, non-negative = no collision
-        // max_dist > 0 means separating plane exists (no collision)
-        // max_dist <= 0 means all planes satisfied (collision)
         return max_dist;
     }
 

--- a/src/impl/vamp/collision/sphere_polytope.hh
+++ b/src/impl/vamp/collision/sphere_polytope.hh
@@ -8,9 +8,6 @@
 
 namespace vamp::collision
 {
-    // Sphere-polytope collision: returns negative if collision
-    // Algorithm: find max signed distance across all planes
-    // If max > 0, separating plane exists (no collision)
     template <typename DataT>
     inline auto sphere_polytope(
         const ConvexPolytope<DataT> &p,
@@ -20,16 +17,16 @@ namespace vamp::collision
         const DataT &r) noexcept -> DataT
     {
         const auto rsq = r * r;
-        auto aabb_dist = sphere_cuboid(p.aabb, cx, cy, cz, rsq);
+        auto obb_dist = sphere_cuboid(p.obb, cx, cy, cz, rsq);
 
-        if (aabb_dist.test_zero())
+        if (obb_dist.test_zero())
         {
-            return aabb_dist;
+            return obb_dist;
         }
 
         DataT max_dist = DataT::fill(-std::numeric_limits<float>::max());
 
-        // TODO: Proper GJK...
+        // TODO: Proper GJK? Seems OK for now.
         for (auto i = 0U; i < p.num_planes; ++i)
         {
             // dist = n.C - d - r (positive = separated)

--- a/src/impl/vamp/collision/validity.hh
+++ b/src/impl/vamp/collision/validity.hh
@@ -6,6 +6,7 @@
 #include <vamp/collision/sphere_capsule.hh>
 #include <vamp/collision/sphere_cuboid.hh>
 #include <vamp/collision/sphere_heightfield.hh>
+#include <vamp/collision/sphere_polytope.hh>
 #include <vamp/collision/math.hh>
 
 namespace vamp
@@ -137,6 +138,20 @@ namespace vamp
             }
         }
 
+        for (const auto &ep : e.polytopes)
+        {
+            const auto diff = ep.min_distance - max_extent;
+            if (diff.test_zero())
+            {
+                break;
+            }
+
+            if (not collision::sphere_polytope(ep, sx, sy, sz, sr).test_zero())
+            {
+                return true;
+            }
+        }
+
         const std::array<DataT, 3> positions = {sx, sy, sz};
         for (const auto &pc : e.pointclouds)
         {
@@ -242,6 +257,20 @@ namespace vamp
             if (not collision::sphere_heightfield(eh, sx, sy, sz, sr).test_zero())
             {
                 objects.emplace_back(eh.name);
+            }
+        }
+
+        for (const auto &ep : e.polytopes)
+        {
+            const auto diff = ep.min_distance - max_extent;
+            if (diff.test_zero())
+            {
+                break;
+            }
+
+            if (not collision::sphere_polytope(ep, sx, sy, sz, sr).test_zero())
+            {
+                objects.emplace_back(ep.name);
             }
         }
 

--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -79,7 +79,7 @@ def mesh_to_polytopes(
     import trimesh
     import numpy as np
 
-    mesh = trimesh.load(str(filename), force='mesh')
+    mesh = trimesh.load(str(filename), force = 'mesh')
 
     if convex_decomposition:
         parts = trimesh.decomposition.convex_decomposition(mesh, **decomposition_kwargs)

--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -81,6 +81,18 @@ def mesh_to_polytopes(
 
     mesh = trimesh.load(str(filename), force = 'mesh')
 
+    def hull_to_polytope(hull, scale, position, polytope_name):
+        vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
+        normals = np.array(hull.face_normals).astype(np.float32)
+        face_vertices = hull.vertices[hull.faces[:, 0]]
+        d_orig = np.sum(normals * face_vertices, axis=1)
+        d_transformed = (d_orig * scale + np.sum(normals * position, axis=1)).astype(np.float32)
+        planes = np.column_stack([normals, d_transformed]).astype(np.float32)
+
+        polytope = ConvexPolytope.from_both(vertices, planes)
+        polytope.name = polytope_name
+        return polytope
+
     if convex_decomposition:
         parts = trimesh.decomposition.convex_decomposition(mesh, **decomposition_kwargs)
         if not isinstance(parts, list):
@@ -94,19 +106,14 @@ def mesh_to_polytopes(
                 part_mesh = part_data
 
             hull = part_mesh.convex_hull
-            vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
-            polytope = ConvexPolytope(vertices)
-            polytope.name = f"{name}_{i}" if len(parts) > 1 else name
-            polytopes.append(polytope)
+            polytope_name = f"{name}_{i}" if len(parts) > 1 else name
+            polytopes.append(hull_to_polytope(hull, scale, position, polytope_name))
 
         return polytopes
 
     else:
         hull = mesh.convex_hull
-        vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
-        polytope = ConvexPolytope(vertices)
-        polytope.name = name
-        return [polytope]
+        return [hull_to_polytope(hull, scale, position, name)]
 
 
 def configure_robot_and_planner_with_kwargs(robot_name: str, planner_name: str, **kwargs):

--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -23,8 +23,7 @@ __all__ = [
     ]
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union, List
-import importlib
+from typing import Any, Dict, Tuple, Union, List
 
 from numpy import float32
 from numpy.typing import NDArray

--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -85,8 +85,8 @@ def mesh_to_polytopes(
         vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
         normals = np.array(hull.face_normals).astype(np.float32)
         face_vertices = hull.vertices[hull.faces[:, 0]]
-        d_orig = np.sum(normals * face_vertices, axis=1)
-        d_transformed = (d_orig * scale + np.sum(normals * position, axis=1)).astype(np.float32)
+        d_orig = np.sum(normals * face_vertices, axis = 1)
+        d_transformed = (d_orig * scale + np.sum(normals * position, axis = 1)).astype(np.float32)
         planes = np.column_stack([normals, d_transformed]).astype(np.float32)
 
         polytope = ConvexPolytope.from_both(vertices, planes)

--- a/src/vamp/__init__.py
+++ b/src/vamp/__init__.py
@@ -1,6 +1,7 @@
 __all__ = [
     "robots",
     "png_to_heightfield",
+    "mesh_to_polytopes",
     "configure_robot_and_planner_with_kwargs",
     "problem_dict_to_vamp",
     "results_to_dict",
@@ -9,6 +10,7 @@ __all__ = [
     "Sphere",
     "Cuboid",
     "Cylinder",
+    "ConvexPolytope",
     "RRTCSettings",
     "PRMSettings",
     "PRMNeighborParams",
@@ -32,6 +34,7 @@ from . import _core
 from ._core import Sphere as Sphere
 from ._core import Cuboid as Cuboid
 from ._core import Cylinder as Cylinder
+from ._core import ConvexPolytope as ConvexPolytope
 from ._core import Attachment as Attachment
 from ._core import Environment as Environment
 from ._core import PRMNeighborParams as PRMNeighborParams
@@ -64,6 +67,47 @@ def png_to_heightfield(
     array = np.flip(array, axis = 0)
 
     return _core.make_heightfield(center, scaling, array.shape, list(array.flatten()))
+
+
+def mesh_to_polytopes(
+    filename: Path,
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    scale: float = 1.0,
+    convex_decomposition: bool = False,
+    name: str = "mesh",
+    **decomposition_kwargs,
+    ) -> List[ConvexPolytope]:
+    import trimesh
+    import numpy as np
+
+    mesh = trimesh.load(str(filename), force='mesh')
+
+    if convex_decomposition:
+        parts = trimesh.decomposition.convex_decomposition(mesh, **decomposition_kwargs)
+        if not isinstance(parts, list):
+            parts = [parts]
+
+        polytopes = []
+        for i, part_data in enumerate(parts):
+            if isinstance(part_data, dict):
+                part_mesh = trimesh.Trimesh(**part_data)
+            else:
+                part_mesh = part_data
+
+            hull = part_mesh.convex_hull
+            vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
+            polytope = ConvexPolytope(vertices)
+            polytope.name = f"{name}_{i}" if len(parts) > 1 else name
+            polytopes.append(polytope)
+
+        return polytopes
+
+    else:
+        hull = mesh.convex_hull
+        vertices = (np.array(hull.vertices) * scale + position).astype(np.float32)
+        polytope = ConvexPolytope(vertices)
+        polytope.name = name
+        return [polytope]
 
 
 def configure_robot_and_planner_with_kwargs(robot_name: str, planner_name: str, **kwargs):

--- a/src/vamp/pybullet_interface.py
+++ b/src/vamp/pybullet_interface.py
@@ -264,33 +264,47 @@ class PyBulletSimulator:
         vertices = np.column_stack([polytope.vx, polytope.vy, polytope.vz])
         hull = ConvexHull(vertices)
 
+        # Normals aren't always outward facing...
+        centroid = vertices.mean(axis = 0)
+        corrected_simplices = []
+        for simplex in hull.simplices:
+            v0, v1, v2 = vertices[simplex]
+            normal = np.cross(v1 - v0, v2 - v0)
+            face_center = (v0 + v1 + v2) / 3
+            to_face = face_center - centroid
+            if np.dot(normal, to_face) < 0:
+                corrected_simplices.append([simplex[0], simplex[2], simplex[1]])
+            else:
+                corrected_simplices.append(simplex.tolist())
+        indices = np.array(corrected_simplices).flatten().tolist()
+
         with DisableRendering(self.client):
             col_shape_id = self.client.createCollisionShape(
                 pb.GEOM_MESH,
-                vertices=vertices.tolist(),
-                indices=hull.simplices.flatten().tolist(),
+                vertices = vertices.tolist(),
+                indices = indices,
                 )
 
             vis_shape_id = self.client.createVisualShape(
                 pb.GEOM_MESH,
-                vertices=vertices.tolist(),
-                indices=hull.simplices.flatten().tolist(),
-                rgbaColor=handle_color(name or polytope.name, color),
+                vertices = vertices.tolist(),
+                indices = indices,
+                rgbaColor = handle_color(name or polytope.name, color),
                 )
 
             multibody_id = self.client.createMultiBody(
-                baseCollisionShapeIndex=col_shape_id,
-                baseVisualShapeIndex=vis_shape_id,
-                basePosition=[0, 0, 0],
+                baseCollisionShapeIndex = col_shape_id,
+                baseVisualShapeIndex = vis_shape_id,
+                basePosition = [0, 0, 0],
                 )
 
             display_name = name or polytope.name
             if display_name:
-                centroid = vertices.mean(axis=0)
+                centroid = vertices.mean(axis = 0)
                 self.client.addUserDebugText(
-                    text=display_name,
-                    textPosition=centroid.tolist(),
-                    textColorRGB=[0., 0., 0.],
+                    text = display_name,
+                    textPosition = centroid.tolist(),
+                    textColorRGB = [0., 0., 0.],
                     )
 
             return multibody_id

--- a/src/vamp/pybullet_interface.py
+++ b/src/vamp/pybullet_interface.py
@@ -253,6 +253,48 @@ class PyBulletSimulator:
 
             return multibody_id
 
+    def add_polytope(
+        self,
+        polytope,
+        name: Optional[str] = None,
+        color: Optional[Union[List[float], str]] = None,
+        ):
+        from scipy.spatial import ConvexHull
+
+        vertices = np.column_stack([polytope.vx, polytope.vy, polytope.vz])
+        hull = ConvexHull(vertices)
+
+        with DisableRendering(self.client):
+            col_shape_id = self.client.createCollisionShape(
+                pb.GEOM_MESH,
+                vertices=vertices.tolist(),
+                indices=hull.simplices.flatten().tolist(),
+                )
+
+            vis_shape_id = self.client.createVisualShape(
+                pb.GEOM_MESH,
+                vertices=vertices.tolist(),
+                indices=hull.simplices.flatten().tolist(),
+                rgbaColor=handle_color(name or polytope.name, color),
+                )
+
+            multibody_id = self.client.createMultiBody(
+                baseCollisionShapeIndex=col_shape_id,
+                baseVisualShapeIndex=vis_shape_id,
+                basePosition=[0, 0, 0],
+                )
+
+            display_name = name or polytope.name
+            if display_name:
+                centroid = vertices.mean(axis=0)
+                self.client.addUserDebugText(
+                    text=display_name,
+                    textPosition=centroid.tolist(),
+                    textColorRGB=[0., 0., 0.],
+                    )
+
+            return multibody_id
+
     def update_object_position(
             self, multibody_id: int, position: Position, rot_xywz: XYZWQuaternion = [0, 0, 0, 1]
         ):


### PR DESCRIPTION
Adds basic polytope obstacle avoidance with OBB broadphase and then checking separation with halfspaces (no GJK yet...). Adds a CPM dependency on cddlib to compute convex hulls and convert between vertex/halfspace representations.

https://github.com/user-attachments/assets/18716d39-36cd-4ffd-8bf1-796a41289cf4

