### PR TITLE
fix compiler warnings

### DIFF
--- a/src/impl/vamp/planning/phs.hh
+++ b/src/impl/vamp/planning/phs.hh
@@ -152,6 +152,8 @@ namespace vamp::planning
         {
         }
 
+        virtual ~ProlateHyperspheroidRNG() = default;
+
         inline void reset() noexcept override
         {
             rng->reset();

--- a/src/impl/vamp/random/halton.hh
+++ b/src/impl/vamp/random/halton.hh
@@ -43,6 +43,8 @@ namespace vamp::rng
         {
         }
 
+        virtual ~Halton() = default;
+
         inline constexpr auto bases() noexcept -> Configuration
         {
             alignas(FloatVectorAlignment) std::array<float, Robot::dimension> a;

--- a/src/impl/vamp/random/xorshift.hh
+++ b/src/impl/vamp/random/xorshift.hh
@@ -20,6 +20,8 @@ namespace vamp::rng
             avx_xorshift128plus_init(key1, key2, &key);
         }
 
+        virtual ~XORShift() = default;
+
         uint64_t key1_init;
         uint64_t key2_init;
 

--- a/src/impl/vamp/robots/baxter.hh
+++ b/src/impl/vamp/robots/baxter.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Baxter
     {
-        static constexpr char *name = "baxter";
+        static constexpr char const* name = "baxter";
         static constexpr std::size_t dimension = 14;
         static constexpr std::size_t n_spheres = 75;
         static constexpr float min_radius = 0.012000000104308128;
@@ -32,7 +32,7 @@ namespace vamp::robots
             "right_w0",
             "right_w1",
             "right_w2"};
-        static constexpr char *end_effector = "right_gripper";
+        static constexpr char const* end_effector = "right_gripper";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/baxter.hh
+++ b/src/impl/vamp/robots/baxter.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Baxter
     {
-        static constexpr char const* name = "baxter";
+        static constexpr const char *name = "baxter";
         static constexpr std::size_t dimension = 14;
         static constexpr std::size_t n_spheres = 75;
         static constexpr float min_radius = 0.012000000104308128;
@@ -32,7 +32,7 @@ namespace vamp::robots
             "right_w0",
             "right_w1",
             "right_w2"};
-        static constexpr char const* end_effector = "right_gripper";
+        static constexpr const char *end_effector = "right_gripper";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/fetch.hh
+++ b/src/impl/vamp/robots/fetch.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Fetch
     {
-        static constexpr char const* name = "fetch";
+        static constexpr const char *name = "fetch";
         static constexpr std::size_t dimension = 8;
         static constexpr std::size_t n_spheres = 111;
         static constexpr float min_radius = 0.012000000104308128;
@@ -26,7 +26,7 @@ namespace vamp::robots
             "forearm_roll_joint",
             "wrist_flex_joint",
             "wrist_roll_joint"};
-        static constexpr char const* end_effector = "gripper_link";
+        static constexpr const char *end_effector = "gripper_link";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/fetch.hh
+++ b/src/impl/vamp/robots/fetch.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Fetch
     {
-        static constexpr char *name = "fetch";
+        static constexpr char const* name = "fetch";
         static constexpr std::size_t dimension = 8;
         static constexpr std::size_t n_spheres = 111;
         static constexpr float min_radius = 0.012000000104308128;
@@ -26,7 +26,7 @@ namespace vamp::robots
             "forearm_roll_joint",
             "wrist_flex_joint",
             "wrist_roll_joint"};
-        static constexpr char *end_effector = "gripper_link";
+        static constexpr char const* end_effector = "gripper_link";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/panda.hh
+++ b/src/impl/vamp/robots/panda.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Panda
     {
-        static constexpr char *name = "panda";
+        static constexpr char const* name = "panda";
         static constexpr std::size_t dimension = 7;
         static constexpr std::size_t n_spheres = 59;
         static constexpr float min_radius = 0.012000000104308128;
@@ -25,7 +25,7 @@ namespace vamp::robots
             "panda_joint5",
             "panda_joint6",
             "panda_joint7"};
-        static constexpr char *end_effector = "panda_grasptarget";
+        static constexpr char const* end_effector = "panda_grasptarget";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/panda.hh
+++ b/src/impl/vamp/robots/panda.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct Panda
     {
-        static constexpr char const* name = "panda";
+        static constexpr const char *name = "panda";
         static constexpr std::size_t dimension = 7;
         static constexpr std::size_t n_spheres = 59;
         static constexpr float min_radius = 0.012000000104308128;
@@ -25,7 +25,7 @@ namespace vamp::robots
             "panda_joint5",
             "panda_joint6",
             "panda_joint7"};
-        static constexpr char const* end_effector = "panda_grasptarget";
+        static constexpr const char *end_effector = "panda_grasptarget";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/sphere.hh
+++ b/src/impl/vamp/robots/sphere.hh
@@ -14,10 +14,10 @@ namespace vamp::robots
 
     struct Sphere
     {
-        static constexpr auto name = "sphere";
-        static constexpr auto dimension = 3;
-        static constexpr auto n_spheres = 1;
-        static constexpr auto resolution = 32;
+        static constexpr char const*  name = "sphere";
+        static constexpr std::size_t dimension = 3;
+        static constexpr std::size_t n_spheres = 1;
+        static constexpr std::size_t resolution = 32;
 
         static constexpr float &min_radius = radius;
         static constexpr float &max_radius = radius;
@@ -34,7 +34,7 @@ namespace vamp::robots
         };
 
         static constexpr std::array<std::string_view, dimension> joint_names = {"x", "y", "z"};
-        static constexpr char *end_effector = "";
+        static constexpr char const* end_effector = "";
 
         template <std::size_t rake>
         struct Spheres

--- a/src/impl/vamp/robots/sphere.hh
+++ b/src/impl/vamp/robots/sphere.hh
@@ -14,7 +14,7 @@ namespace vamp::robots
 
     struct Sphere
     {
-        static constexpr char const*  name = "sphere";
+        static constexpr const char *name = "sphere";
         static constexpr std::size_t dimension = 3;
         static constexpr std::size_t n_spheres = 1;
         static constexpr std::size_t resolution = 32;
@@ -34,7 +34,7 @@ namespace vamp::robots
         };
 
         static constexpr std::array<std::string_view, dimension> joint_names = {"x", "y", "z"};
-        static constexpr char const* end_effector = "";
+        static constexpr const char *end_effector = "";
 
         template <std::size_t rake>
         struct Spheres

--- a/src/impl/vamp/robots/ur5.hh
+++ b/src/impl/vamp/robots/ur5.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct UR5
     {
-        static constexpr char *name = "ur5";
+        static constexpr char const* name = "ur5";
         static constexpr std::size_t dimension = 6;
         static constexpr std::size_t n_spheres = 40;
         static constexpr float min_radius = 0.014999999664723873;
@@ -24,7 +24,7 @@ namespace vamp::robots
             "wrist_1_joint",
             "wrist_2_joint",
             "wrist_3_joint"};
-        static constexpr char *end_effector = "robotiq_85_base_link";
+        static constexpr char const* end_effector ="robotiq_85_base_link";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/robots/ur5.hh
+++ b/src/impl/vamp/robots/ur5.hh
@@ -10,7 +10,7 @@ namespace vamp::robots
 {
     struct UR5
     {
-        static constexpr char const* name = "ur5";
+        static constexpr const char *name = "ur5";
         static constexpr std::size_t dimension = 6;
         static constexpr std::size_t n_spheres = 40;
         static constexpr float min_radius = 0.014999999664723873;
@@ -24,7 +24,7 @@ namespace vamp::robots
             "wrist_1_joint",
             "wrist_2_joint",
             "wrist_3_joint"};
-        static constexpr char const* end_effector ="robotiq_85_base_link";
+        static constexpr const char *end_effector = "robotiq_85_base_link";
 
         using Configuration = FloatVector<dimension>;
         using ConfigurationArray = std::array<FloatT, dimension>;

--- a/src/impl/vamp/vector/interface.hh
+++ b/src/impl/vamp/vector/interface.hh
@@ -19,7 +19,7 @@ namespace vamp
     template <typename S>
     inline constexpr void print_vector(std::ostream &out, typename S::VectorT vec) noexcept
     {
-        for (auto i = 0; i < S::VectorWidth - 1; ++i)
+        for (auto i = 0ul; i < S::VectorWidth - 1; ++i)
         {
             out << S::extract(vec, i) << ", ";
         }
@@ -1033,7 +1033,7 @@ namespace vamp
     {
         o << "[";
 
-        for (auto i = 0; i < v.data.size() - 1; ++i)
+        for (auto i = 0ul; i < v.data.size() - 1; ++i)
         {
             o << " [";
             print_vector<typename VectorIT::S>(o, v.data[i]);


### PR DESCRIPTION
fixes many warnings when compiling with Clang (both clang from Xcode and clang-22). The only warning I didn't fix that shows up in many places is this one:
```
warning: use of infinity is undefined behavior due to the currently enabled floating-point options [-Wnan-infinity-disabled
```